### PR TITLE
Nanny

### DIFF
--- a/bin/dworker
+++ b/bin/dworker
@@ -5,7 +5,7 @@ from sys import argv, exit
 import socket
 
 import click
-from distributed import Nanny, Worker
+from distributed import Nanny, Worker, sync
 from distributed.utils import get_ip
 from tornado.ioloop import IOLoop
 
@@ -15,12 +15,6 @@ ip = get_ip()
 
 # Set up signal handling
 import signal
-
-def handle_signal(sig, frame):
-    IOLoop.instance().add_callback(IOLoop.instance().stop)
-
-signal.signal(signal.SIGINT, handle_signal)
-signal.signal(signal.SIGTERM, handle_signal)
 
 
 @click.command()
@@ -38,21 +32,24 @@ def go(center, host, port, ncores):
         else:
             sock.close()
             break
-    loop = IOLoop()
+
     try:
         center_ip, center_port = center.split(':')
         center_port = int(center_port)
     except IndexError:
         logger.info("Usage:  dworker center_host:center_port")
+
+    loop = IOLoop.current()
+    worker = Nanny(host, port, port + 1, center_ip, center_port, ncores=ncores)
+    loop.add_callback(worker._start)
     try:
-        worker = Nanny(host, port, port + 1, center_ip, center_port, ncores=ncores)
-        loop.run_sync(worker._start)
         loop.start()
     except KeyboardInterrupt:
-        assert worker.status == 'closed'
-
-    IOLoop.current().close()
-    logger.info("\nEnd worker at %s:%d\n", ip, port)
+        result = IOLoop().run_sync(lambda:
+                worker.center.unregister(address=worker.worker_address))
+        if result == b'OK':
+            logger.info("Unregister %s:%d from center", *worker.worker_address)
+        logger.info("End worker at %s:%d", ip, port)
 
 if __name__ == '__main__':
     go()

--- a/bin/dworker
+++ b/bin/dworker
@@ -5,7 +5,7 @@ from sys import argv, exit
 import socket
 
 import click
-from distributed import Worker
+from distributed import Nanny, Worker
 from distributed.utils import get_ip
 from tornado.ioloop import IOLoop
 
@@ -29,15 +29,25 @@ signal.signal(signal.SIGTERM, handle_signal)
 @click.option('--host', type=str, default=ip, help="Serving host")
 @click.option('--ncores', type=int, default=0, help="Number of cores to serve")
 def go(center, host, port, ncores):
+    while True:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(('127.0.0.1', port))
+        except socket.error:
+            port += 1
+        else:
+            sock.close()
+            break
+    loop = IOLoop()
     try:
         center_ip, center_port = center.split(':')
         center_port = int(center_port)
     except IndexError:
         logger.info("Usage:  dworker center_host:center_port")
     try:
-        worker = Worker(host, port, center_ip, center_port, ncores=ncores)
-        worker.start()
-        IOLoop.current().start()
+        worker = Nanny(host, port, port + 1, center_ip, center_port, ncores=ncores)
+        loop.run_sync(worker._start)
+        loop.start()
     except KeyboardInterrupt:
         assert worker.status == 'closed'
 

--- a/bin/dworker
+++ b/bin/dworker
@@ -29,17 +29,6 @@ signal.signal(signal.SIGTERM, handle_signal)
 @click.option('--host', type=str, default=ip, help="Serving host")
 @click.option('--ncores', type=int, default=0, help="Number of cores to serve")
 def go(center, host, port, ncores):
-    while True:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            sock.bind(('127.0.0.1', port))
-        except socket.error:
-            logger.info("Port %d taken.  Trying %d", port, port + 1)
-            port += 1
-        else:
-            sock.close()
-            break
-
     try:
         center_ip, center_port = center.split(':')
         center_port = int(center_port)

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,6 +1,7 @@
 from .center import Center
 from .worker import Worker
 from .client import scatter, gather, delete, clear, rpc
+from .utils import sync
 from .nanny import Nanny
 from .dask import get
 from .executor import Executor, wait, as_completed

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,6 +1,7 @@
 from .center import Center
 from .worker import Worker
 from .client import scatter, gather, delete, clear
+from .nanny import Nanny
 from .dask import get
 from .executor import Executor, wait, as_completed
 

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,6 +1,6 @@
 from .center import Center
 from .worker import Worker
-from .client import scatter, gather, delete, clear
+from .client import scatter, gather, delete, clear, rpc
 from .nanny import Nanny
 from .dask import get
 from .executor import Executor, wait, as_completed

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -47,6 +47,7 @@ class Center(Server):
         self.who_has = defaultdict(set)
         self.has_what = defaultdict(set)
         self.ncores = dict()
+        self.nannies = dict()
         self.status = None
 
         d = {func.__name__: func
@@ -63,9 +64,11 @@ class Center(Server):
         self.stop()
         return b'OK'
 
-    def register(self, stream, address=None, keys=(), ncores=None):
+    def register(self, stream, address=None, keys=(), ncores=None,
+                 nanny_port=None):
         self.has_what[address] = set(keys)
         self.ncores[address] = ncores
+        self.nannies[address] = nanny_port
         logger.info("Register %s", str(address))
         return b'OK'
 
@@ -75,6 +78,8 @@ class Center(Server):
         keys = self.has_what.pop(address)
         with ignoring(KeyError):
             del self.ncores[address]
+        with ignoring(KeyError):
+            del self.nannies[address]
         for key in keys:
             s = self.who_has[key]
             s.remove(address)

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -76,7 +76,10 @@ class Center(Server):
         with ignoring(KeyError):
             del self.ncores[address]
         for key in keys:
-            self.who_has[key].remove(address)
+            s = self.who_has[key]
+            s.remove(address)
+            if not s:
+                del self.who_has[key]
         logger.info("Unregister %s", str(address))
         return b'OK'
 

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -111,7 +111,7 @@ class Center(Server):
 
     def get_ncores(self, stream, addresses=None):
         if addresses is not None:
-            return {k: self.ncores[k] for k in addresses}
+            return {k: self.ncores.get(k, None) for k in addresses}
         else:
             return self.ncores
 

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -53,7 +53,8 @@ class Center(Server):
         d = {func.__name__: func
              for func in [self.add_keys, self.remove_keys, self.get_who_has,
                           self.get_has_what, self.register, self.get_ncores,
-                          self.unregister, self.delete_data, self.terminate]}
+                          self.unregister, self.delete_data, self.terminate,
+                          self.get_nannies]}
         d = {k[len('get_'):] if k.startswith('get_') else k: v for k, v in
                 d.items()}
 
@@ -119,6 +120,12 @@ class Center(Server):
             return {k: self.ncores.get(k, None) for k in addresses}
         else:
             return self.ncores
+
+    def get_nannies(self, stream, addresses=None):
+        if addresses is not None:
+            return {k: self.nannies.get(k, None) for k in addresses}
+        else:
+            return self.nannies
 
     @gen.coroutine
     def delete_data(self, stream, keys=None):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -106,6 +106,7 @@ class Future(WrappedKey):
         return sync(self.executor.loop, self._exception)
 
     def cancelled(self):
+        """ Returns True if the future has been cancelled """
         return self.key not in self.executor.futures
 
     @gen.coroutine
@@ -614,6 +615,11 @@ class Executor(object):
         yield self._start()
 
     def restart(self):
+        """ Restart the distributed network
+
+        This kills all active work, deletes all data on the network, and
+        restarts the worker processes.
+        """
         return sync(self.loop, self._restart)
 
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -596,7 +596,7 @@ class Executor(object):
         for e in events:
             e.set()
 
-        yield All([nanny.instantiate() for nanny in nannies])
+        yield All([nanny.instantiate(close=True) for nanny in nannies])
 
         yield self._sync_center()
         yield self._start()

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -6,6 +6,7 @@ from concurrent import futures
 from functools import wraps, partial
 import itertools
 import logging
+import time
 import uuid
 
 from dask.base import tokenize, normalize_token
@@ -192,6 +193,8 @@ class Executor(object):
         self._loop_thread.start()
         sync(self.loop, self._sync_center)
         self.loop.add_callback(self._go)
+        while not len(self.stacks) == len(self.ncores):
+            time.sleep(0.01)
 
     @gen.coroutine
     def _start(self):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -252,13 +252,6 @@ class Executor(object):
                     self.futures[msg['key']]['exception'] = msg['exception']
                     self.futures[msg['key']]['traceback'] = msg['traceback']
                     self.futures[msg['key']]['event'].set()
-            if msg['op'] == 'cancel-data':
-                events = [self.futures[key]['event'] for key in msg['keys']
-                                                      if key in self.futures]
-                for key in msg['keys']:
-                    self.futures.pop(key, None)
-                for e in events:
-                    e.set()
 
     @gen.coroutine
     def _shutdown(self):
@@ -596,12 +589,6 @@ class Executor(object):
             raise result
         else:
             return result
-
-    @gen.coroutine
-    def _clear(self):
-        self.loop.add_callback(self.scheduler_queue.put_nowait,
-                {'op': 'clear'})
-        yield [d['event'].wait() for d in self.futures.values()]
 
     @gen.coroutine
     def _restart(self):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -625,9 +625,12 @@ class Executor(object):
         for e in events:
             e.set()
 
+
         yield All([nanny.instantiate(close=True) for nanny in nannies])
 
         logger.info("Restarting executor")
+        self.report_queue = Queue()
+        self.scheduler_queue = Queue()
         yield self._start()
 
     def restart(self):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -95,12 +95,13 @@ class Nanny(Server):
         return (self.ip, self.worker_port)
 
 
-def run_worker(q, ip, port, center_ip, center_port, ncores):
+def run_worker(q, ip, port, center_ip, center_port, ncores, nanny_port):
     from distributed import Worker
     from tornado.ioloop import IOLoop
     IOLoop.clear_instance()
     loop = IOLoop(make_current=True)
-    worker = Worker(ip, port, center_ip, center_port, ncores)
+    worker = Worker(ip, port, center_ip, center_port, ncores,
+            nanny_port=nanny_port)
 
     @gen.coroutine
     def start():

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -41,8 +41,7 @@ class Nanny(Server):
         yield self._instantiate()
         self.loop.add_callback(self._watch)
         self.status = 'running'
-        logger.info('Start Nanny at:             %s:%d',
-                    self.center.ip, self.center.port)
+        logger.info('Start Nanny at:             %s:%d', self.ip, self.port)
 
     @gen.coroutine
     def _kill(self, stream=None):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -66,7 +66,7 @@ class Nanny(Server):
         raise gen.Return(b'OK')
 
     @gen.coroutine
-    def _watch(self, wait_seconds=1):
+    def _watch(self, wait_seconds=0.10):
         while True:
             if self.process and not self.process.is_alive():
                 yield self.center.unregister(address=self.worker_address)

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -42,8 +42,11 @@ class Nanny(Server):
     def _kill(self, stream=None, wait=True):
         if self.process:
             self.process.terminate()
-            logger.info("Nanny kills worker process %s:%d", self.ip, self.port)
-            yield self.center.unregister(address=self.worker_address)
+            logger.info("Nanny %s:%d kills worker process %s:%d",
+                        self.ip, self.port, self.ip, self.worker_port)
+            result = yield self.center.unregister(address=self.worker_address)
+            if result != b'OK':
+                logger.critical("Unable to unregister with center. %s", result)
         self.process = None
         raise gen.Return(b'OK')
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -30,7 +30,7 @@ class Nanny(Server):
 
         handlers = {'instantiate': self._instantiate,
                     'kill': self._kill,
-                    'terminate': self.terminate}
+                    'terminate': self._close}
 
         super(Nanny, self).__init__(handlers, **kwargs)
 
@@ -98,17 +98,13 @@ class Nanny(Server):
                 yield gen.sleep(wait_seconds)
 
     @gen.coroutine
-    def _close(self):
+    def _close(self, stream=None):
         """ Close the nanny process, stop listening """
         logger.info("Closing Nanny at %s:%d", self.ip, self.port)
         yield self._kill()
         self.center.close_streams()
         self.stop()
         self.status = 'closed'
-
-    @gen.coroutine
-    def terminate(self, stream=None):
-        yield self._close()
         raise gen.Return(b'OK')
 
     @property

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -50,14 +50,14 @@ class Nanny(Server):
         Blocks until both the process is down and the center is properly
         informed
         """
-        if self.process:
+        if self.process is not None:
             self.process.terminate()
+            self.process = None
             logger.info("Nanny %s:%d kills worker process %s:%d",
                         self.ip, self.port, self.ip, self.worker_port)
             result = yield self.center.unregister(address=self.worker_address)
             if result != b'OK':
                 logger.critical("Unable to unregister with center. %s", result)
-        self.process = None
         raise gen.Return(b'OK')
 
     @gen.coroutine

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -17,7 +17,7 @@ class Nanny(Server):
         self.ip = ip
         self.port = port
         self.worker_port = worker_port
-        self.ncores = ncores or _ncores
+        self.ncores = ncores
         self.status = None
         self.process = None
         self.loop = loop or IOLoop.current()
@@ -82,7 +82,7 @@ class Nanny(Server):
         self.status = 'closed'
 
     @gen.coroutine
-    def terminate(self, stream):
+    def terminate(self, stream=None):
         yield self._close()
         raise gen.Return(b'OK')
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -440,6 +440,21 @@ def scheduler(scheduler_queue, report_queue, worker_queues, delete_queue,
                 held_data.remove(msg['key'])
                 release_key(msg['key'])
 
+        elif msg['op'] == 'clear':
+            keys = set(dsk) | set(who_has)
+
+            for collection in [dsk, dependencies, dependents, in_play, waiting,
+                    waiting_data, held_data, nbytes, restrictions, who_has,
+                    keyorder]:
+                collection.clear()
+
+            for d in [stacks, processing, has_what]:
+                for v in d.values():
+                    v.clear()
+
+            report_queue.put_nowait({'op': 'cancel-data',
+                                     'keys': keys})
+
         else:
             logger.warn("Bad message: %s", msg)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -194,10 +194,12 @@ def scheduler(scheduler_queue, report_queue, worker_queues, delete_queue,
     stacks = dict() if stacks is None else stacks
     processing = dict() if processing is None else processing
 
+    stacks.clear()
     stacks.update({worker: list() for worker in ncores})
+    processing.clear()
     processing.update({worker: set() for worker in ncores})
 
-    assert (not dsk) == (not dependencies)
+    assert (not dsk) == (not dependencies), (dsk, dependencies)
 
     in_play = set(who_has)  # keys in memory, stacks, processing, or waiting
     keyorder = dict()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -467,7 +467,9 @@ def scheduler(scheduler_queue, report_queue, worker_queues, delete_queue,
                     keyorder]:
                 collection.clear()
 
-            for d in [stacks, processing, has_what]:
+            for v in stacks.values():
+                del v[:]
+            for d in [processing, has_what]:
                 for v in d.values():
                     v.clear()
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -459,23 +459,6 @@ def scheduler(scheduler_queue, report_queue, worker_queues, delete_queue,
                 held_data.remove(msg['key'])
                 release_key(msg['key'])
 
-        elif msg['op'] == 'clear':
-            keys = set(dsk) | set(who_has)
-
-            for collection in [dsk, dependencies, dependents, in_play, waiting,
-                    waiting_data, held_data, nbytes, restrictions, who_has,
-                    keyorder]:
-                collection.clear()
-
-            for v in stacks.values():
-                del v[:]
-            for d in [processing, has_what]:
-                for v in d.values():
-                    v.clear()
-
-            report_queue.put_nowait({'op': 'cancel-data',
-                                     'keys': keys})
-
         else:
             logger.warn("Bad message: %s", msg)
 

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -33,6 +33,13 @@ with ignoring(ImportError):
     @sizeof.register(pd.Series)
     def _(s):
         try:
-            return s.memory_usage(index=True, deep=True).sum() # new in 0.17.1
+            return s.memory_usage(index=True, deep=True) # new in 0.17.1
         except:
             return sizeof(s.values) + sizeof(s.index)
+
+    @sizeof.register(pd.Index)
+    def _(i):
+        try:
+            return i.memory_usage(deep=True)
+        except:
+            return i.nbytes

--- a/distributed/tests/test_center.py
+++ b/distributed/tests/test_center.py
@@ -40,6 +40,8 @@ def test_metadata(loop):
 
         response = yield cc.ncores()
         assert response == {'alice': 4, 'bob': 4}
+        response = yield cc.ncores(addresses=['alice', 'charlie'])
+        assert response == {'alice': 4, 'charlie': None}
 
         response = yield cc.unregister(address='alice', close=True)
         assert response == b'OK'

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1152,34 +1152,6 @@ def test_traceback_sync(loop):
             assert tb is None
 
 
-def test_clear(loop):
-    @gen.coroutine
-    def f(c, a, b):
-        e = Executor((c.ip, c.port), start=False, loop=loop)
-        yield e._start()
-
-        x = e.submit(inc, 1)
-        y = e.submit(inc, x)
-        yield x._result()
-
-        yield e._clear()
-
-        start = time()
-        while not x.cancelled() or not y.cancelled():
-            yield gen.sleep(0.01)
-            assert time() - start < 3
-
-        for x in [e.dask, e.waiting, e.held_data, e.nbytes, e.restrictions,
-                e.who_has, e.futures]:
-            assert not x
-
-        for d in [e.has_what, e.stacks, e.processing]:
-            assert all(not v for v in d.values())
-
-        yield e._shutdown()
-    _test_cluster(f, loop)
-
-
 def test_restart(loop):
     from distributed import Nanny, rpc
     c = Center('127.0.0.1', 8006)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1,6 +1,7 @@
 from operator import add, sub
 
 from collections import Iterator
+from concurrent.futures import CancelledError
 from time import sleep, time
 import sys
 
@@ -1233,6 +1234,9 @@ def test_restart_sync(loop):
             e.restart()
             assert not e.who_has
             assert x.cancelled()
+
+            with pytest.raises(CancelledError):
+                x.result()
 
             assert set(e.stacks) == set(e.processing) == set(e.ncores)
             assert len(e.stacks) == 2

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1128,7 +1128,8 @@ def test_traceback(loop):
         x = e.submit(div, 1, 0)
         tb = yield x._traceback()
 
-        assert any('x / y' in line for line in tb)
+        if sys.version_info[0] >= 3:
+            assert any('x / y' in line for line in tb)
 
         yield e._shutdown()
     _test_cluster(f, loop)
@@ -1166,7 +1167,7 @@ def test_clear(loop):
         start = time()
         while not x.cancelled() or not y.cancelled():
             yield gen.sleep(0.01)
-            assert time() - start < 1
+            assert time() - start < 3
 
         for x in [e.dask, e.waiting, e.held_data, e.nbytes, e.restrictions,
                 e.who_has, e.futures]:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1225,6 +1225,7 @@ def test_restart(loop):
 def test_restart_sync(loop):
     with cluster(nanny=True) as (c, [a, b]):
         with Executor(('127.0.0.1', c['port']), loop=loop) as e:
+            assert len(e.has_what) == 2
             x = e.submit(div, 1, 2)
             x.result()
 

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1175,5 +1175,4 @@ def test_clear(loop):
             assert all(not v for v in d.values())
 
         yield e._shutdown()
-
     _test_cluster(f, loop)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1148,3 +1148,32 @@ def test_traceback_sync(loop):
             z = e.submit(div, 1, 2)
             tb = z.traceback()
             assert tb is None
+
+
+def test_clear(loop):
+    @gen.coroutine
+    def f(c, a, b):
+        e = Executor((c.ip, c.port), start=False, loop=loop)
+        yield e._start()
+
+        x = e.submit(inc, 1)
+        y = e.submit(inc, x)
+        yield x._result()
+
+        yield e._clear()
+
+        start = time()
+        while not x.cancelled() or not y.cancelled():
+            yield gen.sleep(0.01)
+            assert time() - start < 1
+
+        for x in [e.dask, e.waiting, e.held_data, e.nbytes, e.restrictions,
+                e.who_has, e.futures]:
+            assert not x
+
+        for d in [e.has_what, e.stacks, e.processing]:
+            assert all(not v for v in d.values())
+
+        yield e._shutdown()
+
+    _test_cluster(f, loop)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -15,18 +15,22 @@ def test_metadata(loop):
         yield n._start()
         assert n.process.is_alive()
         assert c.ncores[n.worker_address] == 2
+        assert c.nannies[n.worker_address] > 8000
 
         yield n._kill()
         assert n.worker_address not in c.ncores
+        assert n.worker_address not in c.nannies
         assert not n.process
 
         yield n._kill()
         assert n.worker_address not in c.ncores
+        assert n.worker_address not in c.nannies
         assert not n.process
 
         yield n._instantiate()
         assert n.process.is_alive()
         assert c.ncores[n.worker_address] == 2
+        assert c.nannies[n.worker_address] > 8000
 
         yield n._close()
         assert not n.process

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -1,13 +1,19 @@
-from distributed import Nanny, Center, rpc
-from distributed.utils_test import loop
+import sys
+from time import time
 
 from tornado.tcpclient import TCPClient
+from tornado.iostream import StreamClosedError
 from tornado import gen
 
-def test_metadata(loop):
+from distributed import Nanny, Center, rpc
+from distributed.utils import ignoring
+from distributed.utils_test import loop
+
+
+def test_nanny(loop):
     c = Center('127.0.0.1', 8006)
     n = Nanny('127.0.0.1', 8007, 8008, '127.0.0.1', 8006, ncores=2)
-    c.listen(8006)
+    c.listen(c.port)
 
     @gen.coroutine
     def f():
@@ -37,5 +43,38 @@ def test_metadata(loop):
 
         if n.process:
             n.process.terminate()
+
+    loop.run_sync(f)
+
+
+def test_nanny_process_failure(loop):
+    c = Center('127.0.0.1', 8016)
+    n = Nanny('127.0.0.1', 8017, 8018, '127.0.0.1', 8016, ncores=2)
+    c.listen(c.port)
+
+    @gen.coroutine
+    def f():
+        nn = rpc(ip=n.ip, port=n.port)
+        yield n._start()
+
+        ww = rpc(ip=n.ip, port=n.worker_port)
+        yield ww.update_data(data={'x': 1, 'y': 2})
+        with ignoring(StreamClosedError):
+            yield ww.compute(function=sys.exit, args=(0,), key='z')
+
+        start = time()
+        while n.process.is_alive():  # wait while process dies
+            yield gen.sleep(0.01)
+            assert time() - start < 2
+
+        start = time()
+        while not n.process.is_alive():  # wait while process comes back
+            yield gen.sleep(0.01)
+            assert time() - start < 2
+
+        start = time()
+        while n.worker_address not in c.ncores:
+            yield gen.sleep(0.01)
+            assert time() - start < 2
 
     loop.run_sync(f)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -44,12 +44,14 @@ def test_nanny(loop):
         if n.process:
             n.process.terminate()
 
+        c.stop()
+
     loop.run_sync(f)
 
 
 def test_nanny_process_failure(loop):
-    c = Center('127.0.0.1', 8016)
-    n = Nanny('127.0.0.1', 8017, 8018, '127.0.0.1', 8016, ncores=2)
+    c = Center('127.0.0.1', 8006)
+    n = Nanny('127.0.0.1', 8007, 8008, '127.0.0.1', 8006, ncores=2)
     c.listen(c.port)
 
     @gen.coroutine

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -1,4 +1,4 @@
-from distributed import Nanny, Center
+from distributed import Nanny, Center, rpc
 from distributed.utils_test import loop
 
 from tornado.tcpclient import TCPClient
@@ -11,28 +11,28 @@ def test_metadata(loop):
 
     @gen.coroutine
     def f():
-        stream = yield TCPClient().connect('127.0.0.1', 8006)
+        nn = rpc(ip=n.ip, port=n.port)
         yield n._start()
         assert n.process.is_alive()
         assert c.ncores[n.worker_address] == 2
         assert c.nannies[n.worker_address] > 8000
 
-        yield n._kill()
+        yield nn.kill()
         assert n.worker_address not in c.ncores
         assert n.worker_address not in c.nannies
         assert not n.process
 
-        yield n._kill()
+        yield nn.kill()
         assert n.worker_address not in c.ncores
         assert n.worker_address not in c.nannies
         assert not n.process
 
-        yield n._instantiate()
+        yield nn.instantiate()
         assert n.process.is_alive()
         assert c.ncores[n.worker_address] == 2
         assert c.nannies[n.worker_address] > 8000
 
-        yield n._close()
+        yield nn.terminate()
         assert not n.process
 
         if n.process:

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -1,0 +1,37 @@
+from distributed import Nanny, Center
+from distributed.utils_test import loop
+
+from tornado.tcpclient import TCPClient
+from tornado import gen
+
+def test_metadata(loop):
+    c = Center('127.0.0.1', 8006)
+    n = Nanny('127.0.0.1', 8007, 8008, '127.0.0.1', 8006, ncores=2)
+    c.listen(8006)
+
+    @gen.coroutine
+    def f():
+        stream = yield TCPClient().connect('127.0.0.1', 8006)
+        yield n._start()
+        assert n.process.is_alive()
+        assert c.ncores[n.worker_address] == 2
+
+        yield n._kill()
+        assert n.worker_address not in c.ncores
+        assert not n.process
+
+        yield n._kill()
+        assert n.worker_address not in c.ncores
+        assert not n.process
+
+        yield n._instantiate()
+        assert n.process.is_alive()
+        assert c.ncores[n.worker_address] == 2
+
+        yield n._close()
+        assert not n.process
+
+        if n.process:
+            n.process.terminate()
+
+    loop.run_sync(f)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -11,8 +11,8 @@ from distributed.utils_test import loop
 
 
 def test_nanny(loop):
-    c = Center('127.0.0.1', 8006)
-    n = Nanny('127.0.0.1', 8007, 8008, '127.0.0.1', 8006, ncores=2)
+    c = Center('127.0.0.1', 8026)
+    n = Nanny('127.0.0.1', 8027, 8028, '127.0.0.1', 8026, ncores=2)
     c.listen(c.port)
 
     @gen.coroutine
@@ -44,14 +44,15 @@ def test_nanny(loop):
         if n.process:
             n.process.terminate()
 
+        yield n._close()
         c.stop()
 
     loop.run_sync(f)
 
 
 def test_nanny_process_failure(loop):
-    c = Center('127.0.0.1', 8006)
-    n = Nanny('127.0.0.1', 8007, 8008, '127.0.0.1', 8006, ncores=2)
+    c = Center('127.0.0.1', 8036)
+    n = Nanny('127.0.0.1', 8037, 8038, '127.0.0.1', 8036, ncores=2)
     c.listen(c.port)
 
     @gen.coroutine
@@ -78,5 +79,8 @@ def test_nanny_process_failure(loop):
         while n.worker_address not in c.ncores:
             yield gen.sleep(0.01)
             assert time() - start < 2
+
+        yield n._close()
+        c.stop()
 
     loop.run_sync(f)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1,4 +1,5 @@
 from operator import add
+import sys
 from time import sleep
 
 from distributed.center import Center
@@ -72,7 +73,8 @@ def test_worker(loop):
                 function=bad_func, args=(), needed=(), close=True)
         assert response == b'error'
         assert isinstance(error, ZeroDivisionError)
-        assert any('1 / 0' in line for line in traceback)
+        if sys.version_info[0] >= 3:
+            assert any('1 / 0' in line for line in traceback)
 
         aa.close_streams()
         yield a._close()

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from collections import Iterable
 import socket
+import sys
 
 from tornado import gen
 
@@ -84,3 +85,9 @@ def sync(loop, func, *args, **kwargs):
 import logging
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
                     level=logging.INFO)
+
+# http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
+stream = logging.StreamHandler(sys.stderr)
+stream.setLevel(logging.CRITICAL)
+logging.getLogger('tornado').addHandler(stream)
+logging.getLogger('tornado').propagate = False

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -54,7 +54,7 @@ def run_nanny(port, center_port, **kwargs):
     IOLoop.clear_instance()
     loop = IOLoop(make_current=True)
     logging.getLogger("tornado").setLevel(logging.CRITICAL)
-    worker = Nanny('127.0.0.1', port, port + 1, '127.0.0.1', center_port, **kwargs)
+    worker = Nanny('127.0.0.1', port, port + 1000, '127.0.0.1', center_port, **kwargs)
     loop.run_sync(worker._start)
     loop.start()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -158,7 +158,7 @@ class Worker(Server):
                     yield gen.with_timeout(timedelta(seconds=1), future)
                     break
                 except gen.TimeoutError:
-                    logger.info("Pending job %d: %s", i, future)
+                    logger.debug("Pending job %d: %s", i, future)
             result = future.result()
             logger.info("Finish job %d: %s", i, funcname(function))
             self.data[key] = result

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -62,9 +62,10 @@ class Worker(Server):
     """
 
     def __init__(self, ip, port, center_ip, center_port, ncores=None,
-                 loop=None, **kwargs):
+                 loop=None, nanny_port=None, **kwargs):
         self.ip = ip
         self.port = port
+        self.nanny_port = nanny_port
         self.ncores = ncores or _ncores
         self.data = dict()
         self.loop = loop or IOLoop.current()
@@ -95,7 +96,8 @@ class Worker(Server):
         while True:
             try:
                 resp = yield self.center.register(
-                        ncores=self.ncores, address=(self.ip, self.port))
+                        ncores=self.ncores, address=(self.ip, self.port),
+                        nanny_port=self.nanny_port)
                 break
             except OSError:
                 yield gen.sleep(1)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -88,7 +88,7 @@ class Worker(Server):
                 logger.info('Start worker at             %s:%d', self.ip, self.port)
                 self.listen(self.port)
                 break
-            except OSError:
+            except (OSError, IOError):
                 logger.info('Port %d taken. Trying %d', self.port, self.port + 1)
                 self.port += 1
 

--- a/docs/source/executor.rst
+++ b/docs/source/executor.rst
@@ -116,6 +116,22 @@ with existing dask code.
    499999359.23511785
 
 
+``restart``
+~~~~~~~~~~~
+
+When things go wrong, restart the cluster with the ``.restart()`` method.
+
+.. code-block:: python
+
+   >>> executor.restart()
+
+This both resets the local scheduler state and restarts all worker processes.
+All current data and computations will be lost.  All existing futures set their
+status to ``'cancelled'``.
+
+See :doc:`resilience <resilence>` for more information.
+
+
 Internals
 ---------
 

--- a/docs/source/resilience.rst
+++ b/docs/source/resilience.rst
@@ -68,3 +68,33 @@ remain on the cluster until cleared.
 
     >>> from distributed.client import clear
     >>> clear('center-ip:8787')
+
+
+Restart and Nanny Processes
+---------------------------
+
+The executor provides a mechanism to restart all of the workers in the cluster.
+This is convenient if, during the course of experimentation, you find your
+workers in an inconvenient state that makes them unresponsive.  The
+``Executor.restart`` method does the following process:
+
+1.  Sends a soft shutdown signal to all of the coroutines watching workers
+2.  Sends a hard kill signal to each worker's Nanny process, which oversees
+    that worker.  This Nanny process terminates the worker process
+    ungracefully and unregisters that worker from the Center.
+3.  Clears out all scheduler state and sets all Future's status to
+    ``'cancelled'``
+4.  Sends a restart signal to all Nanny processes, which in turn restart clean
+    Worker processes and register these workers with the Center.  New workers
+    may not have the same port as their previous iterations.  The
+    ``.nannies`` dictionary on the Executor serves as an accurate set of
+    aliases if necessary.
+5.  Restarts the scheduler, with clean and empty state
+
+This effectively removes all data and clears out all computations from the
+scheduler.  Any data or computations not saved to persistent storage are
+lost.  This process is very robust to a number of failure modes, including
+non-responsive or swamped workers but not including full hardware failures.
+
+Currently the user may experience a number of Error logging messages from
+Tornado upon closing their session.  These can safely be ignored.


### PR DESCRIPTION
Add nanny processes and executor restart functionality.

On a restart we clear out current work, kill the workers, bring them back up, and restart the scheduler.  It should provide a reliably clean environment even in fairly bad situations.

```python
In [1]: from distributed import Executor

In [2]: e = Executor('192.168.1.141:8787')

In [3]: x = e.submit(lambda x: x + 1, 10)

In [4]: e.who_has
Out[4]: defaultdict(<class 'set'>, {'<lambda>-4f0eddb7ea55a9e40bfd77b9b15ea7c0': {('192.168.1.141', 8808)}})

In [5]: %time e.restart()
CPU times: user 35.5 ms, sys: 7.62 ms, total: 43.1 ms
Wall time: 150 ms

In [6]: e.who_has
Out[6]: defaultdict(<class 'set'>, {})

In [7]: x.result()
CancelledError: <lambda>-4f0eddb7ea55a9e40bfd77b9b15ea7c0
```

@broxtronix @freeman-lab

### TODO

- [x] Shut down scheduler coroutines impolitely (we still wait for them to complete, which can take a while)
- [x] Document nanny behavior
- [x] Resolve intermittent error with nanny's starting on ports already claimed by workers