### PR TITLE
Upload package

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -6,6 +6,7 @@ from concurrent import futures
 from functools import wraps, partial
 import itertools
 import logging
+import os
 import time
 import uuid
 
@@ -583,12 +584,12 @@ class Executor(object):
     def _upload_package(self, filename):
         with open(filename, 'rb') as f:
             data = f.read()
+        _, fn = os.path.split(filename)
         d = yield self.center.broadcast(msg={'op': 'upload_package',
-                                             'filename': filename,
+                                             'filename': fn,
                                              'data': data})
 
-        assert all(v == b'OK' for v in d.values())
-        raise gen.Return(b'OK')
+        assert all(len(data) == v for v in d.values())
 
     def upload_package(self, filename):
         """ Upload local package to workers

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -581,17 +581,17 @@ class Executor(object):
         return sync(self.loop, self._restart)
 
     @gen.coroutine
-    def _upload_package(self, filename):
+    def _upload_file(self, filename):
         with open(filename, 'rb') as f:
             data = f.read()
         _, fn = os.path.split(filename)
-        d = yield self.center.broadcast(msg={'op': 'upload_package',
+        d = yield self.center.broadcast(msg={'op': 'upload_file',
                                              'filename': fn,
                                              'data': data})
 
         assert all(len(data) == v for v in d.values())
 
-    def upload_package(self, filename):
+    def upload_file(self, filename):
         """ Upload local package to workers
 
         Parameters
@@ -599,7 +599,7 @@ class Executor(object):
         filename: string
             Filename of .py file to send to workers
         """
-        return sync(self.loop, self._upload_package, filename)
+        return sync(self.loop, self._upload_file, filename)
 
 
 @gen.coroutine

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -579,6 +579,27 @@ class Executor(object):
         """
         return sync(self.loop, self._restart)
 
+    @gen.coroutine
+    def _upload_package(self, filename):
+        with open(filename, 'rb') as f:
+            data = f.read()
+        d = yield self.center.broadcast(msg={'op': 'upload_package',
+                                             'filename': filename,
+                                             'data': data})
+
+        assert all(v == b'OK' for v in d.values())
+        raise gen.Return(b'OK')
+
+    def upload_package(self, filename):
+        """ Upload local package to workers
+
+        Parameters
+        ----------
+        filename: string
+            Filename of .py file to send to workers
+        """
+        return sync(self.loop, self._upload_package, filename)
+
 
 @gen.coroutine
 def _wait(fs, timeout=None, return_when='ALL_COMPLETED'):

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 from multiprocessing import Process, Queue, queues
+import tempfile
 
 from tornado.ioloop import IOLoop
 from tornado import gen
@@ -18,7 +19,7 @@ class Nanny(Server):
     them as necessary.
     """
     def __init__(self, ip, port, worker_port, center_ip, center_port,
-                ncores=None, loop=None, local_dir='pkgs', **kwargs):
+                ncores=None, loop=None, local_dir=None, **kwargs):
         self.ip = ip
         self.port = port
         self.worker_port = worker_port

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 from multiprocessing import Process, Queue, queues
-import os
 
 from tornado.ioloop import IOLoop
 from tornado import gen
@@ -31,8 +30,7 @@ class Nanny(Server):
 
         handlers = {'instantiate': self._instantiate,
                     'kill': self._kill,
-                    'terminate': self._close,
-                    'upload_package': self.upload_package}
+                    'terminate': self._close}
 
         super(Nanny, self).__init__(handlers, **kwargs)
 
@@ -109,11 +107,6 @@ class Nanny(Server):
         self.status = 'closed'
         raise gen.Return(b'OK')
 
-    def upload_package(self, stream, filename=None, data=None):
-        with open(os.path.join('pkgs', filename), 'wb') as f:
-            f.write(data)
-        return b'OK'
-
     @property
     def address(self):
         return (self.ip, self.port)
@@ -127,10 +120,6 @@ def run_worker(q, ip, port, center_ip, center_port, ncores, nanny_port):
     """ Function run by the Nanny when creating the worker """
     from distributed import Worker
     from tornado.ioloop import IOLoop
-    import sys
-    if not os.path.exists('pkgs'):
-        os.mkdir('pkgs')
-    sys.path.append('pkgs')
     IOLoop.clear_instance()
     loop = IOLoop()
     loop.make_current()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -18,11 +18,12 @@ class Nanny(Server):
     them as necessary.
     """
     def __init__(self, ip, port, worker_port, center_ip, center_port,
-                ncores=None, loop=None, **kwargs):
+                ncores=None, loop=None, local_dir='pkgs', **kwargs):
         self.ip = ip
         self.port = port
         self.worker_port = worker_port
         self.ncores = ncores
+        self.local_dir = local_dir
         self.status = None
         self.process = None
         self.loop = loop or IOLoop.current()
@@ -72,7 +73,7 @@ class Nanny(Server):
         self.process = Process(target=run_worker,
                                args=(q, self.ip, self.worker_port, self.center.ip,
                                      self.center.port, self.ncores,
-                                     self.port))
+                                     self.port, self.local_dir))
         self.process.daemon = True
         self.process.start()
         logger.info("Nanny starts worker process %s:%d", self.ip, self.port)
@@ -116,7 +117,8 @@ class Nanny(Server):
         return (self.ip, self.worker_port)
 
 
-def run_worker(q, ip, port, center_ip, center_port, ncores, nanny_port):
+def run_worker(q, ip, port, center_ip, center_port, ncores, nanny_port,
+        local_dir):
     """ Function run by the Nanny when creating the worker """
     from distributed import Worker
     from tornado.ioloop import IOLoop
@@ -124,7 +126,7 @@ def run_worker(q, ip, port, center_ip, center_port, ncores, nanny_port):
     loop = IOLoop()
     loop.make_current()
     worker = Worker(ip, port, center_ip, center_port, ncores,
-                    nanny_port=nanny_port)
+                    nanny_port=nanny_port, local_dir=local_dir)
 
     @gen.coroutine
     def start():

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 from multiprocessing import Process, Queue, queues
+import os
 
 from tornado.ioloop import IOLoop
 from tornado import gen
@@ -30,7 +31,8 @@ class Nanny(Server):
 
         handlers = {'instantiate': self._instantiate,
                     'kill': self._kill,
-                    'terminate': self._close}
+                    'terminate': self._close,
+                    'upload_package': self.upload_package}
 
         super(Nanny, self).__init__(handlers, **kwargs)
 
@@ -107,6 +109,11 @@ class Nanny(Server):
         self.status = 'closed'
         raise gen.Return(b'OK')
 
+    def upload_package(self, stream, filename=None, data=None):
+        with open(os.path.join('pkgs', filename), 'wb') as f:
+            f.write(data)
+        return b'OK'
+
     @property
     def address(self):
         return (self.ip, self.port)
@@ -120,6 +127,10 @@ def run_worker(q, ip, port, center_ip, center_port, ncores, nanny_port):
     """ Function run by the Nanny when creating the worker """
     from distributed import Worker
     from tornado.ioloop import IOLoop
+    import sys
+    if not os.path.exists('pkgs'):
+        os.mkdir('pkgs')
+    sys.path.append('pkgs')
     IOLoop.clear_instance()
     loop = IOLoop()
     loop.make_current()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8,35 +8,9 @@ from tornado.ioloop import IOLoop
 
 from distributed import Center, Worker
 from distributed.utils import ignoring
-from distributed.utils_test import cluster, loop
+from distributed.utils_test import cluster, loop, _test_cluster
 from distributed.client import (RemoteData, _gather, _scatter, _delete, _clear,
         scatter_to_workers, pack_data, gather, scatter, delete, clear)
-
-
-def _test_cluster(f, loop=None):
-    @gen.coroutine
-    def g():
-        c = Center('127.0.0.1', 8017)
-        c.listen(c.port)
-        a = Worker('127.0.0.1', 8018, c.ip, c.port, ncores=1)
-        yield a._start()
-        b = Worker('127.0.0.1', 8019, c.ip, c.port, ncores=1)
-        yield b._start()
-
-        while len(c.ncores) < 2:
-            yield gen.sleep(0.01)
-
-        try:
-            yield f(c, a, b)
-        finally:
-            with ignoring():
-                yield a._close()
-            with ignoring():
-                yield b._close()
-            c.stop()
-
-    loop = loop or IOLoop.current()
-    loop.run_sync(g)
 
 
 def test_scatter_delete(loop):

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1283,7 +1283,7 @@ def test_fast_kill(loop):
     loop.run_sync(f)
 
 
-def test_upload_package(loop):
+def test_upload_file(loop):
     @gen.coroutine
     def f(c, a, b):
         e = Executor((c.ip, c.port), start=False, loop=loop)
@@ -1297,7 +1297,7 @@ def test_upload_package(loop):
             return myfile.x
 
         with tmp_text('myfile.py', 'x = 123') as fn:
-            yield e._upload_package(fn)
+            yield e._upload_file(fn)
 
             x = e.submit(g)
             result = yield x._result()
@@ -1307,7 +1307,7 @@ def test_upload_package(loop):
     _test_cluster(f, loop)
 
 
-def test_upload_package_sync(loop):
+def test_upload_file_sync(loop):
     with cluster() as (c, [a, b]):
         with Executor(('127.0.0.1', c['port'])) as e:
             def g():
@@ -1318,6 +1318,6 @@ def test_upload_package_sync(loop):
             os.mkdir('pkgs')
 
             with tmp_text('myfile.py', 'x = 123') as fn:
-                e.upload_package(fn)
+                e.upload_file(fn)
                 x = e.submit(g)
                 assert x.result() == 123

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1289,9 +1289,6 @@ def test_upload_file(loop):
         e = Executor((c.ip, c.port), start=False, loop=loop)
         yield e._start()
 
-        shutil.rmtree('pkgs')
-        os.mkdir('pkgs')
-
         def g():
             import myfile
             return myfile.x
@@ -1313,9 +1310,6 @@ def test_upload_file_sync(loop):
             def g():
                 import myfile
                 return myfile.x
-
-            shutil.rmtree('pkgs')
-            os.mkdir('pkgs')
 
             with tmp_text('myfile.py', 'x = 123') as fn:
                 e.upload_file(fn)

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -84,30 +84,3 @@ def test_nanny_process_failure(loop):
         c.stop()
 
     loop.run_sync(f)
-
-
-def test_upload_package(loop):
-    c = Center('127.0.0.1', 8026)
-    n = Nanny('127.0.0.1', 8027, 8028, '127.0.0.1', 8026, ncores=2)
-    c.listen(c.port)
-
-    @gen.coroutine
-    def f():
-        nn = rpc(ip=n.ip, port=n.port)
-        yield n._start()
-
-        yield nn.upload_package(filename='foobar.py', data=b'x = 123')
-
-        def f():
-            import foobar
-            return foobar.x
-
-        ww = rpc(ip=n.ip, port=n.worker_port)
-        yield ww.compute(function=f, key='x')
-        result = yield ww.get_data(keys=['x'])
-        assert result == {'x': 123}
-
-        yield n._close()
-        c.stop()
-
-    loop.run_sync(f)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -136,13 +136,13 @@ def test_delete_data_with_missing_worker(loop):
     _test_cluster(f)
 
 
-def test_upload_package(loop):
+def test_upload_file(loop):
     @gen.coroutine
     def f(c, a, b):
         if os.path.exists(os.path.join('pkgs', 'foobar.py')):
             os.remove(os.path.join('pkgs', 'foobar.py'))
         aa = rpc(ip=a.ip, port=a.port)
-        yield aa.upload_package(filename='foobar.py', data=b'x = 123')
+        yield aa.upload_file(filename='foobar.py', data=b'x = 123')
 
         def g():
             import foobar

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -155,6 +155,18 @@ def test_upload_package(loop):
         aa.close_streams()
 
     _test_cluster(f)
+
+
+def test_broadcast(loop):
+    @gen.coroutine
+    def f(c, a, b):
+        cc = rpc(ip=c.ip, port=c.port)
+        results = yield cc.broadcast(msg={'op': 'ping'})
+        assert results == {a.address: b'pong', b.address: b'pong'}
+
+        cc.close_streams()
+
+    _test_cluster(f)
 """
 
 def test_close():

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -99,7 +99,7 @@ def tmp_text(filename, text):
 
 import logging
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s',
-                    level=logging.DEBUG)
+                    level=logging.INFO)
 
 # http://stackoverflow.com/questions/21234772/python-tornado-disable-logging-to-stderr
 stream = logging.StreamHandler(sys.stderr)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, division, absolute_import
 
 from collections import Iterable
+import os
 import socket
 import sys
+import tempfile
 
 from tornado import gen
 
@@ -80,6 +82,19 @@ def sync(loop, func, *args, **kwargs):
     a = loop.add_callback(f)
     e.wait()
     return result[0]
+
+
+@contextmanager
+def tmp_text(filename, text):
+    fn = os.path.join(tempfile.gettempdir(), filename)
+    with open(fn, 'w') as f:
+        f.write(text)
+
+    try:
+        yield fn
+    finally:
+        if os.path.exists(fn):
+            os.remove(fn)
 
 
 import logging

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from contextlib import contextmanager
+from glob import glob
 import logging
 from multiprocessing import Process
 import os
@@ -84,7 +85,8 @@ def cluster(nworkers=2, nanny=False):
     for i in range(nworkers):
         _port[0] += 1
         port = _port[0]
-        proc = Process(target=_run_worker, args=(port, cport), kwargs={'ncores': 1})
+        proc = Process(target=_run_worker, args=(port, cport),
+                        kwargs={'ncores': 1, 'local_dir': '_test_worker-%d' % port})
         workers.append({'port': port, 'proc': proc})
 
     center.start()
@@ -114,6 +116,8 @@ def cluster(nworkers=2, nanny=False):
         for proc in [center] + [w['proc'] for w in workers]:
             with ignoring(Exception):
                 proc.terminate()
+        for fn in glob('_test_worker-*'):
+            shutil.rmtree(fn)
 
 
 import pytest

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -3,6 +3,8 @@ from __future__ import print_function, division, absolute_import
 from contextlib import contextmanager
 import logging
 from multiprocessing import Process
+import os
+import shutil
 import socket
 from time import time
 
@@ -146,10 +148,11 @@ def _test_cluster(f, loop=None):
             yield f(c, a, b)
         finally:
             logger.debug("Closing out test cluster")
-            with ignoring():
-                yield a._close()
-            with ignoring():
-                yield b._close()
+            for w in [a, b]:
+                with ignoring():
+                    yield w._close()
+                if os.path.exists(w.local_dir):
+                    shutil.rmtree(w.local_dir)
             c.stop()
 
     loop = loop or IOLoop.current()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 import logging
 from multiprocessing.pool import ThreadPool
+import os
 import traceback
 import sys
 
@@ -22,6 +23,11 @@ _ncores = ThreadPool()._processes
 
 
 logger = logging.getLogger(__name__)
+
+if not os.path.exists('pkgs'):
+    os.mkdir('pkgs')
+
+sys.path.append('pkgs')
 
 
 class Worker(Server):
@@ -79,7 +85,8 @@ class Worker(Server):
                     'update_data': self.update_data,
                     'delete_data': self.delete_data,
                     'terminate': self.terminate,
-                    'ping': pingpong}
+                    'ping': pingpong,
+                    'upload_package': self.upload_package}
 
         super(Worker, self).__init__(handlers, **kwargs)
 
@@ -207,6 +214,11 @@ class Worker(Server):
 
     def get_data(self, stream, keys=None):
         return {k: self.data[k] for k in keys if k in self.data}
+
+    def upload_package(self, stream, filename=None, data=None):
+        with open(os.path.join('pkgs', filename), 'wb') as f:
+            f.write(data)
+        return b'OK'
 
 
 job_counter = [0]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -87,7 +87,7 @@ class Worker(Server):
                     'delete_data': self.delete_data,
                     'terminate': self.terminate,
                     'ping': pingpong,
-                    'upload_package': self.upload_package}
+                    'upload_file': self.upload_file}
 
         super(Worker, self).__init__(handlers, **kwargs)
 
@@ -216,7 +216,7 @@ class Worker(Server):
     def get_data(self, stream, keys=None):
         return {k: self.data[k] for k in keys if k in self.data}
 
-    def upload_package(self, stream, filename=None, data=None):
+    def upload_file(self, stream, filename=None, data=None):
         with open(os.path.join('pkgs', filename), 'wb') as f:
             f.write(data)
             f.flush()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -218,7 +218,8 @@ class Worker(Server):
     def upload_package(self, stream, filename=None, data=None):
         with open(os.path.join('pkgs', filename), 'wb') as f:
             f.write(data)
-        return b'OK'
+            f.flush()
+        return len(data)
 
 
 job_counter = [0]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import logging
 from multiprocessing.pool import ThreadPool
 import os
+import tempfile
 import traceback
 import shutil
 import sys
@@ -65,7 +66,7 @@ class Worker(Server):
     """
 
     def __init__(self, ip, port, center_ip, center_port, ncores=None,
-                 loop=None, nanny_port=None, local_dir='pkgs', **kwargs):
+                 loop=None, nanny_port=None, local_dir=None, **kwargs):
         self.ip = ip
         self.port = port
         self.nanny_port = nanny_port
@@ -73,15 +74,15 @@ class Worker(Server):
         self.data = dict()
         self.loop = loop or IOLoop.current()
         self.status = None
-        self.local_dir = local_dir
+        self.local_dir = local_dir or tempfile.mkdtemp(prefix='worker-')
         self.executor = ThreadPoolExecutor(self.ncores)
         self.center = rpc(ip=center_ip, port=center_port)
 
-        if not os.path.exists(local_dir):
-            os.mkdir(local_dir)
+        if not os.path.exists(self.local_dir):
+            os.mkdir(self.local_dir)
 
-        if local_dir not in sys.path:
-            sys.path.append(local_dir)
+        if self.local_dir not in sys.path:
+            sys.path.append(self.local_dir)
 
         handlers = {'compute': self.compute,
                     'get_data': self.get_data,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -24,11 +24,6 @@ _ncores = ThreadPool()._processes
 
 logger = logging.getLogger(__name__)
 
-if not os.path.exists('pkgs'):
-    os.mkdir('pkgs')
-
-sys.path.append('pkgs')
-
 
 class Worker(Server):
     """ Worker Node
@@ -69,7 +64,7 @@ class Worker(Server):
     """
 
     def __init__(self, ip, port, center_ip, center_port, ncores=None,
-                 loop=None, nanny_port=None, **kwargs):
+                 loop=None, nanny_port=None, local_dir='pkgs', **kwargs):
         self.ip = ip
         self.port = port
         self.nanny_port = nanny_port
@@ -79,6 +74,12 @@ class Worker(Server):
         self.status = None
         self.executor = ThreadPoolExecutor(self.ncores)
         self.center = rpc(ip=center_ip, port=center_port)
+
+        if not os.path.exists(local_dir):
+            os.mkdir(local_dir)
+
+        if local_dir not in sys.path:
+            sys.path.append(local_dir)
 
         handlers = {'compute': self.compute,
                     'get_data': self.get_data,


### PR DESCRIPTION
This allows us to push local files out to the workers.  It works with the following changes.

1.  Workers have an `upload_package` route that accepts a filename and bytes.  It writes those bytes to the filename in a local `pkgs/` directory that gets created in the local directory (should we change this to a temp directory?).  This directory is added to `sys.path` explicitly.
2.  Centers gain a `broadcast` route that we can use to send messages to all of the workers
3.  The `Executor` gains an `upload_package` method, that sends to the center to broadcast out to the workers the filename and content of a local file.  Presumably that file could be a .py or .egg file.  I've only tested this with .py files.

This may be unsafe in various ways.  Feedback on better approaches welcome.

```python
In [1]: cat fib.py
def fib(i):
    if i in (0, 1):
        return i
    else:
        return fib(i - 1) + fib(i - 2)

In [2]: from distributed import Executor

In [3]: e = Executor('127.0.0.1:8787')

In [4]: e.upload_package('fib.py')

In [5]: from fib import fib

In [6]: x = e.submit(fib, 10)

In [7]: x.result()
Out[7]: 55
```

cc @quasiben @danielfrg @broxtronix @freeman-lab