### PR TITLE
Reload modules on upload

### DIFF
--- a/distributed/compatibility.py
+++ b/distributed/compatibility.py
@@ -4,9 +4,12 @@ import sys
 
 if sys.version_info[0] == 2:
     from Queue import Queue
+    reload = reload
 
 if sys.version_info[0] == 3:
     from queue import Queue
+    from importlib import reload
+
 
 try:
     from functools import singledispatch

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -105,6 +105,7 @@ class Nanny(Server):
                 yield self._close()
                 break
             if self.process and not self.process.is_alive():
+                logger.info("Discovered failed worker.  Restarting")
                 self.cleanup()
                 yield self.center.unregister(address=self.worker_address)
                 yield self._instantiate()

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1323,3 +1323,26 @@ def test_upload_file_sync(loop):
                 e.upload_file(fn)
                 x = e.submit(g)
                 assert x.result() == 123
+
+
+def test_upload_file_exception(loop):
+    @gen.coroutine
+    def f(c, a, b):
+        e = Executor((c.ip, c.port), start=False, loop=loop)
+        yield e._start()
+
+        with tmp_text('myfile.py', 'syntax-error!') as fn:
+            with pytest.raises(SyntaxError):
+                yield e._upload_file(fn)
+
+        yield e._shutdown()
+
+    _test_cluster(f, loop)
+
+
+def test_upload_file_exception_sync(loop):
+    with cluster() as (c, [a, b]):
+        with Executor(('127.0.0.1', c['port'])) as e:
+            with tmp_text('myfile.py', 'syntax-error!') as fn:
+                with pytest.raises(SyntaxError):
+                    e.upload_file(fn)

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -1291,14 +1291,22 @@ def test_upload_file(loop):
 
         def g():
             import myfile
-            return myfile.x
+            return myfile.f()
 
-        with tmp_text('myfile.py', 'x = 123') as fn:
+        with tmp_text('myfile.py', 'def f():\n    return 123') as fn:
             yield e._upload_file(fn)
 
-            x = e.submit(g)
-            result = yield x._result()
-            assert result == 123
+        sleep(1)  # TODO:  why is this necessary?
+        x = e.submit(g, pure=False)
+        result = yield x._result()
+        assert result == 123
+
+        with tmp_text('myfile.py', 'def f():\n    return 456') as fn:
+            yield e._upload_file(fn)
+
+        y = e.submit(g, pure=False)
+        result = yield y._result()
+        assert result == 456
 
         yield e._shutdown()
     _test_cluster(f, loop)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -251,6 +251,7 @@ class Worker(Server):
                         reload(import_module(pkg.project_name))
             except Exception as e:
                 logger.exception(e)
+                return e
         return len(data)
 
 


### PR DESCRIPTION
This reloads a module when we upload a .py or .egg file to the cluster.  It works fine in practice but fails tests (and is still a bit brittle.)

I'm not confident that I'm pursuing the correct approach here.  Feedback welcome.