### PR TITLE
Improved formatting of single and multi progress bars.  Added light C…

### DIFF
--- a/distributed/diagnostics.py
+++ b/distributed/diagnostics.py
@@ -387,10 +387,9 @@ class ProgressWidget(Progress):
         from ipywidgets import FloatProgress, HBox, VBox, HTML
         self.elapsed_time = HTML('')
         self.bar = FloatProgress(min=0, max=1, description='', height = '10px')
-        self.bar_text = HTML('')
-        self.bar_label = HTML('<div style="padding: 0px 10px 0px 10px; text-align:right; word-wrap: break-word;">Progress:</div>', width = "300px")
+        self.bar_text = HTML('', width = "140px")
 
-        self.bar_widget = HBox([ VBox([self.bar_label]), VBox([ HBox([self.bar, self.bar_text]) ]) ])
+        self.bar_widget = HBox([ self.bar_text, self.bar ])
         self.widget = VBox([self.elapsed_time, self.bar_widget])
 
         clear_errors(errors)
@@ -423,7 +422,7 @@ class ProgressWidget(Progress):
         ndone = ntasks - len(self.keys)
         self.elapsed_time.value = '<div style=\"padding: 0px 10px 5px 10px\"><b>Elapsed time:</b> ' + format_time(self.elapsed) + '</div>'
         self.bar.value = ndone / ntasks if ntasks else 1.0
-        self.bar_text.value = '<div style="padding: 0px 10px 0px 10px">%d / %d</div>' % (ndone, ntasks)
+        self.bar_text.value = '<div style="padding: 0px 10px 0px 10px; text-align:right;">%d / %d</div>' % (ndone, ntasks)
 
 class MultiProgressWidget(MultiProgress):
     """ Multiple progress bar Widget suitable for the notebook
@@ -455,22 +454,23 @@ class MultiProgressWidget(MultiProgress):
 
         # Set up widgets
         from ipywidgets import FloatProgress, HBox, VBox, HTML
+        import html
         self.elapsed_time = HTML('')
         self.bars = {key: FloatProgress(min=0, max=1, description='', height = '10px')
                         for key in self.all_keys}
-        self.bar_texts = {key: HTML('') for key in self.all_keys}
-        self.bar_labels = {key: HTML('<div style=\"padding: 0px 10px 0px 10px; text-align:right; word-wrap: break-word;\">' + key + ':</div>', width = '300px') for key in self.all_keys}
+        self.bar_texts = {key: HTML('', width = "140px") for key in self.all_keys}
+        self.bar_labels = {key: HTML('<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">' + html.escape(key) + '</div>') for key in self.all_keys}
 
         # Check to see if 'finalize' is one of the keys. If it is, move it to
         # the end so that it is rendered last in the list (for aesthetics...)
         key_order = set(self.all_keys.keys())
         if 'finalize' in key_order:
             key_order.remove('finalize')
-            key_order = list(key_order) + ['finalize']
+            key_order = sorted(list(key_order)) + ['finalize']
         else:
             key_order = list(key_order)
 
-        self.bar_widgets = VBox([ HBox([ self.bar_labels[key], self.bars[key], self.bar_texts[key] ]) for key in key_order ])
+        self.bar_widgets = VBox([ HBox([ self.bar_texts[key], self.bars[key], self.bar_labels[key] ]) for key in key_order ])
         self.widget = VBox([self.elapsed_time, self.bar_widgets])
 
         from tornado.ioloop import IOLoop
@@ -505,7 +505,7 @@ class MultiProgressWidget(MultiProgress):
             ndone = ntasks - len(self.keys[k])
             self.elapsed_time.value = '<div style="padding: 0px 10px 5px 10px"><b>Elapsed time:</b> ' + format_time(self.elapsed) + '</div>'
             self.bars[k].value = ndone / ntasks if ntasks else 1.0
-            self.bar_texts[k].value = '<div style="padding: 0px 10px 0px 10px">%d / %d</div>' % (ndone, ntasks)
+            self.bar_texts[k].value = '<div style="padding: 0px 10px 0px 10px; text-align: right">%d / %d</div>' % (ndone, ntasks)
 
 
 def progress(*futures, **kwargs):

--- a/distributed/tests/test_widgets.py
+++ b/distributed/tests/test_widgets.py
@@ -221,7 +221,7 @@ def test_values(loop):
             assert len(p.all_keys['inc']) == 5
             assert p.status == 'finished'
             assert not p.pc.is_running()
-            assert p.bar_texts['inc'].value == '5 / 5'
+            assert '5 / 5' in p.bar_texts['inc'].value
             assert p.bars['inc'].value == 1.0
 
             x = e.submit(throws, 1)
@@ -248,7 +248,7 @@ def test_progressbar_done(loop):
             p = ProgressWidget([f])
             p.start()
             assert p.status == 'error'
-            assert p.bar.value == 1.0
+            assert p.bar.value == 0.0
             assert p.bar.bar_style == 'danger'
 
 

--- a/distributed/tests/test_widgets.py
+++ b/distributed/tests/test_widgets.py
@@ -97,7 +97,7 @@ def test_progressbar_widget(loop):
 
         progress._update()
         assert progress.bar.value == 1.0
-        assert 's' in progress.bar.description
+        assert '3 / 3' in progress.bar_text.value
 
         sched.put_nowait({'op': 'close'})
         yield done
@@ -142,9 +142,9 @@ def test_multi_progressbar_widget(loop):
         assert p.bars['x'].value == 1.0
         assert p.bars['y'].value == 0.0
         assert p.bars['e'].value == 0.0
-        assert '3 / 3' in p.texts['x'].value
-        assert '0 / 2' in p.texts['y'].value
-        assert '0 / 1' in p.texts['e'].value
+        assert '3 / 3' in p.bar_texts['x'].value
+        assert '0 / 2' in p.bar_texts['y'].value
+        assert '0 / 1' in p.bar_texts['e'].value
 
         while True:
             msg = yield report.get()
@@ -221,7 +221,7 @@ def test_values(loop):
             assert len(p.all_keys['inc']) == 5
             assert p.status == 'finished'
             assert not p.pc.is_running()
-            assert p.texts['inc'].value == '5 / 5'
+            assert p.bar_texts['inc'].value == '5 / 5'
             assert p.bars['inc'].value == 1.0
 
             x = e.submit(throws, 1)
@@ -279,8 +279,8 @@ def test_multibar_complete(loop):
         assert set(concat(p.all_keys.values())) == {'x-1', 'x-2', 'x-3', 'y-1',
                 'y-2', 'e'}
         assert all(b.value == 1.0 for b in p.bars.values())
-        assert p.texts['x'].value == '3 / 3'
-        assert p.texts['y'].value == '2 / 2'
+        assert p.bar_texts['x'].value == '3 / 3'
+        assert p.bar_texts['y'].value == '2 / 2'
 
         sched.put_nowait({'op': 'close'})
         yield done


### PR DESCRIPTION
Here is an attempt to better format the progress bars.  Some notes:

The [ipywidgets](https://github.com/ipython/ipywidgets) library has come a long way and provides some useful tools for modifying CSS properties and laying out widgets, but not all CSS properties are exposed in its API.  Some useful ones like `padding` and `margin` must still be specified manually, so there is some manual CSS code embedded in the `HTML()` objects here to achieve reasonably good looking results.

The updated progress bars behave as follows:

* Elapsed time is shown at the top.  If the computation fails for some reason, the text changes to reflect  an error condition has occurred, and it notes the final elapsed time.
* The progress bars are roughly aligned with the center iPython notebook.  This leaves a healthy amount of space for the text labels on the left side of the progress bars, since function names are often quite long.  The label width is fixed at 300px, and label names wrap if they are too long. 
* Added the `num_completed / num_total` display for `multi = False`. In general, styling and output for `multi = True` and `multi=False` should be identical, so a mix of both look good in the notebook.
* Progress bars no longer fill up to 100% when a computation fails, though they still turn red.  (It's sort of useful to know how far the computation got when it failed.)

@mrocklin, let me know if you have any feedback!