### PR TITLE
Have Scheduler serve as Center

### DIFF
--- a/bin/dscheduler
+++ b/bin/dscheduler
@@ -15,7 +15,7 @@ ip = get_ip()
 
 
 @click.command()
-@click.argument('center', type=str)
+@click.argument('center', type=str, default='')
 @click.option('--port', type=int, default=8786, help="Serving port")
 def go(center, port):
     while True:
@@ -28,15 +28,10 @@ def go(center, port):
             sock.close()
             break
 
-    try:
-        center_ip, center_port = center.split(':')
-        center_port = int(center_port)
-    except IndexError:
-        logger.info("Usage:  dscheduler center_host:center_port")
-
     loop = IOLoop.current()
-    scheduler = Scheduler((center_ip, center_port))
-    loop.run_sync(scheduler.sync_center)
+    scheduler = Scheduler(center)
+    if center:
+        loop.run_sync(scheduler.sync_center)
     done = scheduler.start()
     scheduler.listen(port)
 

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -11,7 +11,7 @@ from tornado.gen import Return
 from tornado.iostream import StreamClosedError
 
 from .core import Server, read, write, rpc, pingpong, send_recv
-from .utils import ignoring, ignore_exceptions, All
+from .utils import ignoring, ignore_exceptions, All, get_ip
 
 
 logger = logging.getLogger(__name__)

--- a/distributed/center.py
+++ b/distributed/center.py
@@ -112,6 +112,8 @@ class Center(Server):
     def register(self, stream, address=None, keys=(), ncores=None,
                  nanny_port=None):
         self.has_what[address] = set(keys)
+        for key in keys:
+            self.who_has[key].add(address)
         self.ncores[address] = ncores
         self.nannies[address] = nanny_port
         logger.info("Register %s", str(address))

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -255,8 +255,11 @@ class Executor(object):
                 self.scheduler = r
                 self.scheduler_stream = yield connect(*self._start_arg)
                 yield write(self.scheduler_stream, {'op': 'start-control'})
-                cip, cport = ident['center']
-                self.center = rpc(ip=cip, port=cport)
+                if 'center' in ident:
+                    cip, cport = ident['center']
+                    self.center = rpc(ip=cip, port=cport)
+                else:
+                    self.center = None
             else:
                 raise ValueError("Unknown Type")
 

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -259,7 +259,7 @@ class Executor(object):
                     cip, cport = ident['center']
                     self.center = rpc(ip=cip, port=cport)
                 else:
-                    self.center = None
+                    self.center = self.scheduler
             else:
                 raise ValueError("Unknown Type")
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -344,7 +344,8 @@ class Scheduler(Server):
                     {'op': 'compute-task',
                      'key': key,
                      'task': self.dask[key],
-                     'needed': self.dependencies[key]})
+                     'who_has': {dep: self.who_has[dep] for dep in
+                                 self.dependencies[key]}})
 
     def seed_ready_tasks(self, keys=None):
         """ Distribute many leaf tasks among workers
@@ -737,7 +738,7 @@ class Scheduler(Server):
                 break
             if msg['op'] == 'compute-task':
                 key = msg['key']
-                needed = msg['needed']
+                who_has = msg['who_has']
                 task = msg['task']
                 if not istask(task):
                     response, content = yield worker.update_data(data={key: task})
@@ -746,7 +747,7 @@ class Scheduler(Server):
                 else:
                     response, content = yield worker.compute(function=execute_task,
                                                              args=(task,),
-                                                             needed=needed,
+                                                             who_has=who_has,
                                                              key=key,
                                                              kwargs={})
                     if response == b'OK':

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -151,7 +151,7 @@ class Worker(Server):
         needed = [n for n in needed if n not in self.data]
 
         # gather data from peers
-        if needed:
+        if needed or who_has:
             logger.info("gather %d keys from peers: %s", len(needed), str(needed))
             try:
                 if who_has is not None:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -146,7 +146,7 @@ class Worker(Server):
 
     @gen.coroutine
     def compute(self, stream, function=None, key=None, args=(), kwargs={},
-            needed=[], who_has=None):
+            needed=[], who_has=None, report=True):
         """ Execute function """
         needed = [n for n in needed if n not in self.data]
 
@@ -196,11 +196,12 @@ class Worker(Server):
             result = future.result()
             logger.info("Finish job %d: %s - %s", i, funcname(function), key)
             self.data[key] = result
-            response = yield self.center.add_keys(address=(self.ip, self.port),
-                                                  keys=[key])
-            if not response == b'OK':
-                logger.warn('Could not report results of work to center: %s',
-                            response.decode())
+            if report:
+                response = yield self.center.add_keys(address=(self.ip, self.port),
+                                                      keys=[key])
+                if not response == b'OK':
+                    logger.warn('Could not report results to center: %s',
+                                response.decode())
             out = (b'OK', {'nbytes': sizeof(result)})
         except Exception as e:
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -107,7 +107,7 @@ class Worker(Server):
             try:
                 resp = yield self.center.register(
                         ncores=self.ncores, address=(self.ip, self.port),
-                        nanny_port=self.nanny_port)
+                        nanny_port=self.nanny_port, keys=list(self.data))
                 break
             except OSError:
                 logger.debug("Unable to register with center.  Waiting")


### PR DESCRIPTION
The scheduler now has most of the capabilities necessary to serve as center, making the center process extraneous.  

Everything is dual mode, so you can work both ways, we might want to consider dropping the local scheduler option though, so that the Executor always communicates to the scheduler over a socket (even if they're in the same process.)