### PR TITLE
Refactor scheduler tests

### DIFF
--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -206,7 +206,7 @@ class Executor(object):
     --------
     distributed.scheduler.Scheduler: Internal scheduler
     """
-    def __init__(self, address, start=True, delete_batch_time=1, loop=None):
+    def __init__(self, address, start=True, loop=None):
         self.futures = dict()
         self.refcount = defaultdict(lambda: 0)
         self.loop = loop or IOLoop()
@@ -214,7 +214,7 @@ class Executor(object):
         self._start_arg = address
 
         if start:
-            self.start(delete_batch_time=delete_batch_time)
+            self.start()
 
     def start(self, **kwargs):
         """ Start scheduler running in separate thread """
@@ -302,7 +302,7 @@ class Executor(object):
         if key in self.futures:
             self.futures[key]['event'].clear()
             del self.futures[key]
-        self._send_to_scheduler({'op': 'release-held-data', 'key': key})
+        self._send_to_scheduler({'op': 'release-held-data', 'keys': [key]})
 
     @gen.coroutine
     def _handle_report(self, start_event):

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -689,7 +689,7 @@ class Executor(object):
                          [v._keys() for v in val])
                     for opt, val in groups.items()])
         names = ['finalize-%s' % tokenize(v) for v in variables]
-        dsk2 = {name: (v._finalize, v, v._keys()) for name, v in zip(names, variables)}
+        dsk2 = {name: (v._finalize, v._keys()) for name, v in zip(names, variables)}
 
         dsk3 = {k: unpack_remotedata(v)[0] for k, v in merge(dsk, dsk2).items()}
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -552,6 +552,10 @@ class Scheduler(Server):
 
         This happens whenever the Executor calls submit, map, get, or compute.
         """
+        for k in list(dsk):
+            if dsk[k] is k:
+                del dsk[k]
+
         update_state(self.dask, self.dependencies, self.dependents,
                 self.held_data, self.who_has, self.in_play,
                 self.waiting, self.waiting_data, dsk, keys)

--- a/distributed/tests/test_center.py
+++ b/distributed/tests/test_center.py
@@ -6,51 +6,48 @@ from tornado.ioloop import IOLoop
 
 from distributed.core import read, write, rpc
 from distributed.center import Center
-from distributed.utils_test import loop
+from distributed.utils_test import loop, gen_test
 
 
-def test_metadata(loop):
+@gen_test()
+def test_metadata():
     c = Center('127.0.0.1')
     c.listen(8006)
 
-    @gen.coroutine
-    def f():
-        stream = yield TCPClient().connect('127.0.0.1', 8006)
+    stream = yield TCPClient().connect('127.0.0.1', 8006)
 
-        cc = rpc(stream)
-        response = yield cc.register(address='alice', ncores=4)
-        assert 'alice' in c.has_what
-        assert c.ncores['alice'] == 4
+    cc = rpc(stream)
+    response = yield cc.register(address='alice', ncores=4)
+    assert 'alice' in c.has_what
+    assert c.ncores['alice'] == 4
 
-        response = yield cc.add_keys(address='alice', keys=['x', 'y'])
-        assert response == b'OK'
+    response = yield cc.add_keys(address='alice', keys=['x', 'y'])
+    assert response == b'OK'
 
-        response = yield cc.register(address='bob', ncores=4)
-        response = yield cc.add_keys(address='bob', keys=['y', 'z'])
-        assert response == b'OK'
+    response = yield cc.register(address='bob', ncores=4)
+    response = yield cc.add_keys(address='bob', keys=['y', 'z'])
+    assert response == b'OK'
 
-        response = yield cc.who_has(keys=['x', 'y'])
-        assert response == {'x': set(['alice']), 'y': set(['alice', 'bob'])}
+    response = yield cc.who_has(keys=['x', 'y'])
+    assert response == {'x': set(['alice']), 'y': set(['alice', 'bob'])}
 
-        response = yield cc.remove_keys(address='bob', keys=['y'])
-        assert response == b'OK'
+    response = yield cc.remove_keys(address='bob', keys=['y'])
+    assert response == b'OK'
 
-        response = yield cc.has_what(keys=['alice', 'bob'])
-        assert response == {'alice': set(['x', 'y']), 'bob': set(['z'])}
+    response = yield cc.has_what(keys=['alice', 'bob'])
+    assert response == {'alice': set(['x', 'y']), 'bob': set(['z'])}
 
-        response = yield cc.ncores()
-        assert response == {'alice': 4, 'bob': 4}
-        response = yield cc.ncores(addresses=['alice', 'charlie'])
-        assert response == {'alice': 4, 'charlie': None}
+    response = yield cc.ncores()
+    assert response == {'alice': 4, 'bob': 4}
+    response = yield cc.ncores(addresses=['alice', 'charlie'])
+    assert response == {'alice': 4, 'charlie': None}
 
-        response = yield cc.unregister(address='alice', close=True)
-        assert response == b'OK'
-        assert 'alice' not in c.has_what
-        assert 'alice' not in c.ncores
+    response = yield cc.unregister(address='alice', close=True)
+    assert response == b'OK'
+    assert 'alice' not in c.has_what
+    assert 'alice' not in c.ncores
 
-        c.stop()
-
-    IOLoop.current().run_sync(f)
+    c.stop()
 
 """
 def test_delete_data():

--- a/distributed/tests/test_collections.py
+++ b/distributed/tests/test_collections.py
@@ -62,7 +62,7 @@ def test_futures_to_dask_dataframe(loop):
             assert ddf.x.sum().compute(get=e.get) == sum([df.x.sum() for df in dfs])
 
 
-@gen_cluster()
+@gen_cluster(timeout=120)
 def test_dataframes(s, a, b):
     e = Executor((s.ip, s.port), start=False)
     yield e._start()
@@ -101,7 +101,7 @@ def test_dataframes(s, a, b):
         assert_equal(local, remote)
 
 
-@gen_cluster()
+@gen_cluster(timeout=60)
 def test__futures_to_dask_array(s, a, b):
     import dask.array as da
     e = Executor((s.ip, s.port), start=False)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -440,7 +440,7 @@ def test_scheduler(s, a, b):
            'dsk': {'x': (inc, 1),
                    'y': (inc, 'x'),
                    'z': (inc, 'y')},
-           'keys': ['z']})
+           'keys': ['x', 'z']})
     while True:
         msg = yield report.get()
         if msg['op'] == 'key-in-memory' and msg['key'] == 'z':
@@ -673,3 +673,12 @@ def test_scheduler_as_center():
     assert s.who_has == {}
 
     yield s.close()
+
+
+@gen_cluster()
+def test_delete_data(s, a, b):
+    yield s.scatter(data={'x': 1, 'y': 2, 'z': 3})
+    assert set(a.data) | set(b.data) == {'x', 'y', 'z'}
+
+    yield s.delete_data(keys=['x', 'y'])
+    assert set(a.data) | set(b.data) == {'z'}

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -682,3 +682,12 @@ def test_delete_data(s, a, b):
 
     yield s.delete_data(keys=['x', 'y'])
     assert set(a.data) | set(b.data) == {'z'}
+
+
+@gen_cluster()
+def test_rpc(s, a, b):
+    aa = s.rpc(ip=a.ip, port=a.port)
+    aa2 = s.rpc(ip=a.ip, port=a.port)
+    bb = s.rpc(ip=b.ip, port=b.port)
+    assert aa is aa2
+    assert aa is not bb

--- a/distributed/tests/test_utils_test.py
+++ b/distributed/tests/test_utils_test.py
@@ -1,5 +1,8 @@
-from distributed.utils_test import cluster, loop, scheduler
+from distributed.utils_test import (cluster, loop, scheduler, gen_cluster,
+        gen_test)
 from distributed.core import rpc
+from distributed import Scheduler, Worker
+from tornado import gen
 
 def test_cluster(loop):
     with cluster() as (c, [a, b]):
@@ -12,3 +15,16 @@ def test_scheduler(loop):
             r = rpc(ip='127.0.0.1', port=sport)
             resp = loop.run_sync(r.ncores)
             assert len(resp) == 2
+
+
+@gen_cluster()
+def test_gen_cluster(s, a, b):
+    assert isinstance(s, Scheduler)
+    for w in [a, b]:
+        assert isinstance(w, Worker)
+    assert s.ncores == {w.address: w.ncores for w in [a, b]}
+
+
+@gen_test()
+def test_gen_test():
+    yield gen.sleep(0.01)

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -341,7 +341,7 @@ def end_cluster(s, workers):
     s.stop()
 
 
-def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)]):
+def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)], timeout=10):
     """ Coroutine test with small cluster
 
     @gen_cluster()
@@ -362,7 +362,7 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)]):
 
             s, workers = loop.run_sync(lambda: start_cluster(ncores))
             try:
-                loop.run_sync(lambda: cor(s, *workers))
+                loop.run_sync(lambda: cor(s, *workers), timeout=timeout)
             finally:
                 loop.run_sync(lambda: end_cluster(s, workers))
                 loop.stop()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -360,11 +360,11 @@ def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)]):
             loop = IOLoop()
             loop.make_current()
 
-            s, workers = loop.run_sync(lambda: start(ncores))
+            s, workers = loop.run_sync(lambda: start_cluster(ncores))
             try:
                 loop.run_sync(lambda: cor(s, *workers))
             finally:
-                loop.run_sync(lambda: end(s, workers))
+                loop.run_sync(lambda: end_cluster(s, workers))
                 loop.stop()
                 loop.close()
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -284,3 +284,89 @@ def _test_scheduler(f, loop=None, b_ip='127.0.0.1'):
     loop = loop or IOLoop.current()
     loop.run_sync(g)
     _global_executor[0] = None
+
+
+def gen_test(timeout=10):
+    """ Coroutine test
+
+    @gen_test(timeout=5)
+    def test_foo():
+        yield ...  # use tornado coroutines
+    """
+    def _(func):
+        def test_func():
+            IOLoop.clear_instance()
+            loop = IOLoop()
+            loop.make_current()
+
+            cor = gen.coroutine(func)
+            try:
+                loop.run_sync(cor, timeout=timeout)
+            finally:
+                loop.stop()
+                loop.close()
+        return test_func
+    return _
+
+
+
+from .scheduler import Scheduler
+from .worker import Worker
+from .executor import Executor
+
+@gen.coroutine
+def start_cluster(ncores):
+    s = Scheduler(ip='127.0.0.1')
+    s.listen(0)
+    workers = [Worker(s.ip, s.port, ncores=v, ip=k) for k, v in ncores]
+
+    IOLoop.current().add_callback(s.start)
+    yield [w._start() for w in workers]
+
+    start = time()
+    while len(s.ncores) < len(ncores):
+        yield gen.sleep(0.01)
+        if time() - start > 5:
+            raise Exception("Cluster creation timeout")
+    raise gen.Return((s, workers))
+
+@gen.coroutine
+def end_cluster(s, workers):
+    logger.debug("Closing out test cluster")
+    for w in workers:
+        with ignoring(TimeoutError, StreamClosedError, OSError):
+            yield w._close()
+        if os.path.exists(w.local_dir):
+            shutil.rmtree(w.local_dir)
+    s.stop()
+
+
+def gen_cluster(ncores=[('127.0.0.1', 1), ('127.0.0.1', 2)]):
+    """ Coroutine test with small cluster
+
+    @gen_cluster()
+    def test_foo(scheduler, worker1, worker2):
+        yield ...  # use tornado coroutines
+
+    See also:
+        start
+        end
+    """
+    def _(func):
+        cor = gen.coroutine(func)
+
+        def test_func():
+            IOLoop.clear_instance()
+            loop = IOLoop()
+            loop.make_current()
+
+            s, workers = loop.run_sync(lambda: start(ncores))
+            try:
+                loop.run_sync(lambda: cor(s, *workers))
+            finally:
+                loop.run_sync(lambda: end(s, workers))
+                loop.stop()
+                loop.close()
+
+        return test_func
+    return _

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -148,17 +148,25 @@ class Worker(Server):
     def compute(self, stream, function=None, key=None, args=(), kwargs={},
             needed=[], who_has=None, report=True):
         """ Execute function """
-        needed = [n for n in needed if n not in self.data]
+        if needed:
+            needed = [n for n in needed if n not in self.data]
+        if who_has:
+            who_has = {k: v for k, v in who_has.items() if k not in self.data}
 
         # gather data from peers
         if needed or who_has:
-            logger.info("gather %d keys from peers: %s", len(needed), str(needed))
             try:
-                if who_has is not None:
+                if who_has:
+                    logger.info("gather %d keys from peers: %s", len(who_has),
+                            str(who_has))
                     other = yield gather_from_workers(who_has)
-                else:
+                elif needed:
+                    logger.info("gather %d keys from peers: %s", len(needed),
+                            str(needed))
                     other = yield _gather(self.center, needed=needed)
                     other = dict(zip(needed, other))
+                else:
+                    raise ValueError()
             except KeyError as e:
                 logger.warn("Could not find data during gather in compute", e)
                 raise Return((b'missing-data', e))


### PR DESCRIPTION
This refactor of the test suite accomplishes two changes

1.  Tests functions are now commonly coroutines.  This reduces common boilerplate
2.  Test functions commonly assume the new Scheduler+Workers configuration, rather than the Center+Workers configuration