### PR TITLE
Have dworker process wait for dcenter on OS X

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -12,7 +12,7 @@ from distributed.worker import Worker
 from distributed.utils_test import loop, _test_cluster, inc
 
 from tornado import gen
-from tornado.ioloop import IOLoop
+from tornado.ioloop import IOLoop, TimeoutError
 
 
 def test_worker_ncores():
@@ -237,6 +237,20 @@ def test_worker_with_port_zero(loop):
         assert w.port > 1024
 
     loop.run_sync(f)
+
+
+def test_worker_waits_for_center_to_come_up(loop):
+    @gen.coroutine
+    def f():
+        w = Worker('127.0.0.1', 8007, ip='127.0.0.1')
+        yield w._start()
+
+    try:
+        loop.run_sync(f, timeout=5)
+    except TimeoutError:
+        pass
+
+
 """
 
 def test_close():

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -8,6 +8,7 @@ from distributed.core import rpc
 from distributed.sizeof import sizeof
 from distributed.worker import Worker
 from distributed.utils_test import loop, _test_cluster, inc
+import pytest
 
 from tornado import gen
 from tornado.ioloop import TimeoutError
@@ -236,7 +237,7 @@ def test_worker_with_port_zero(loop):
 
     loop.run_sync(f)
 
-
+@pytest.mark.slow
 def test_worker_waits_for_center_to_come_up(loop):
     @gen.coroutine
     def f():
@@ -244,7 +245,7 @@ def test_worker_waits_for_center_to_come_up(loop):
         yield w._start()
 
     try:
-        loop.run_sync(f, timeout=5)
+        loop.run_sync(f, timeout=4)
     except TimeoutError:
         pass
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2,17 +2,15 @@ from operator import add
 import os
 import shutil
 import sys
-from time import sleep
 
 from distributed.center import Center
-from distributed.core import read, write, rpc, connect
+from distributed.core import rpc
 from distributed.sizeof import sizeof
-from distributed.utils import ignoring
 from distributed.worker import Worker
 from distributed.utils_test import loop, _test_cluster, inc
 
 from tornado import gen
-from tornado.ioloop import IOLoop, TimeoutError
+from tornado.ioloop import TimeoutError
 
 
 def test_worker_ncores():

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -22,7 +22,7 @@ from .client import _gather, pack_data, gather_from_workers
 from .compatibility import reload
 from .core import rpc, Server, pingpong
 from .sizeof import sizeof
-from .utils import funcname, get_ip, ignoring
+from .utils import funcname, get_ip
 
 _ncores = ThreadPool()._processes
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -16,6 +16,7 @@ from toolz import merge
 from tornado.gen import Return
 from tornado import gen
 from tornado.ioloop import IOLoop, PeriodicCallback
+from tornado.iostream import StreamClosedError
 
 from .client import _gather, pack_data, gather_from_workers
 from .compatibility import reload
@@ -109,7 +110,7 @@ class Worker(Server):
                         ncores=self.ncores, address=(self.ip, self.port),
                         nanny_port=self.nanny_port, keys=list(self.data))
                 break
-            except OSError:
+            except (OSError, StreamClosedError):
                 logger.debug("Unable to register with center.  Waiting")
                 yield gen.sleep(0.5)
         assert resp == b'OK'


### PR DESCRIPTION
if Center is not already running, Worker process throws a ```StreamClosedError``` on OSX. This PR handles the new type of error and fixes #61. Moreover, some of the import statements that were superfluous in the code were also removed.