### PR TITLE
add --no-nanny flag to dworker

### DIFF
--- a/bin/dworker
+++ b/bin/dworker
@@ -26,7 +26,8 @@ ip = get_ip()
               help="Number of threads per process. Defaults to number of cores")
 @click.option('--nprocs', type=int, default=1,
               help="Number of worker processes.  Defaults to one.")
-def go(center, host, port, nthreads, nprocs):
+@click.option('--no-nanny', is_flag=True)
+def go(center, host, port, nthreads, nprocs, no_nanny):
     try:
         center_ip, center_port = center.split(':')
         center_port = int(center_port)
@@ -44,7 +45,8 @@ def go(center, host, port, nthreads, nprocs):
         raise ValueError("Can not specify a port when using multiple processes")
 
     loop = IOLoop.current()
-    nannies = [Nanny(center_ip, center_port, ncores=nthreads, ip=host)
+    t = Worker if no_nanny else Nanny
+    nannies = [t(center_ip, center_port, ncores=nthreads, ip=host)
                 for i in range(nprocs)]
 
     for nanny in nannies:
@@ -52,12 +54,13 @@ def go(center, host, port, nthreads, nprocs):
     try:
         loop.start()
     except KeyboardInterrupt:
-        @gen.coroutine
-        def stop():
-            results = yield [nanny._kill() for nanny in nannies]
-            raise gen.Return(results)
+        if not no_nanny:
+            @gen.coroutine
+            def stop():
+                results = yield [nanny._kill() for nanny in nannies]
+                raise gen.Return(results)
 
-        results = IOLoop().run_sync(stop)
+            results = IOLoop().run_sync(stop)
 
         for r, nanny in zip(results, nannies):
             if r == b'OK':


### PR DESCRIPTION
This starts up a Worker directly, rather than wrapping
with a Nanny.

cc @hussainsultan 

I'm a little concerned about the trend of adding lots of flags to dworker.  Lets see where this goes though.  We might choose another option down the road.