### PR TITLE
Conda recipes for distributed

### DIFF
--- a/conda-recipes/README.md
+++ b/conda-recipes/README.md
@@ -1,0 +1,28 @@
+## Building conda packages
+
+Conda packages for distributed and its dependencies can be built using the
+following commands (tested on Ubuntu 14.04):
+
+```
+export CONDA_DIR=~/miniconda2
+
+sudo apt-get update
+sudo apt-get install -y -q git
+
+curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -o ~/miniconda.sh
+bash ~/miniconda.sh -b -p $CONDA_DIR
+$CONDA_DIR/bin/conda install conda-build anaconda-client -y
+
+git clone https://github.com/blaze/distributed.git ~/distributed
+cd ~/distributed/conda-recipes
+$CONDA_DIR/bin/conda build distributed --python 2.7 --python 3.4 --python 3.5
+
+cd ~/$CONDA_DIR/conda-bld/linux-64
+~/miniconda2/bin/conda convert --platform osx-64 *.tar.bz2 -o ../
+~/miniconda2/bin/conda convert --platform win-64 *.tar.bz2 -o ../
+
+$CONDA_DIR/bin/anaconda login
+$CONDA_DIR/bin/anaconda upload $CONDA_DIR/conda-bld/linux-64/*.tar.bz2 -u blaze
+$CONDA_DIR/bin/anaconda upload $CONDA_DIR/conda-bld/osx-64/*.tar.bz2 -u blaze
+$CONDA_DIR/bin/anaconda upload $CONDA_DIR/conda-bld/win-64/*.tar.bz2 -u blaze
+```

--- a/conda-recipes/boto3/bld.bat
+++ b/conda-recipes/boto3/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipes/boto3/build.sh
+++ b/conda-recipes/boto3/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda-recipes/boto3/meta.yaml
+++ b/conda-recipes/boto3/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: boto3
+  version: "1.2.3"
+
+source:
+  fn: boto3-1.2.3.tar.gz
+  url: https://pypi.python.org/packages/source/b/boto3/boto3-1.2.3.tar.gz
+  md5: 3f45656baef1f1e9ef9aecefb33d898b
+
+requirements:
+  build:
+    - python
+    - botocore >=1.3.0,<1.4.0
+    - jmespath >=0.7.1,<1.0.0
+    - futures                 [py27]
+
+  run:
+    - python
+    - botocore >=1.3.0,<1.4.0
+    - jmespath >=0.7.1,<1.0.0
+    - futures                 [py27]
+
+test:
+  imports:
+    - boto3
+    - boto3.docs
+    - boto3.dynamodb
+    - boto3.ec2
+    - boto3.resources
+    - boto3.s3
+
+about:
+  home: https://github.com/boto/boto3
+  license: Apache Software License
+  summary: 'The AWS SDK for Python'

--- a/conda-recipes/botocore/bld.bat
+++ b/conda-recipes/botocore/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipes/botocore/build.sh
+++ b/conda-recipes/botocore/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda-recipes/botocore/meta.yaml
+++ b/conda-recipes/botocore/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: botocore
+  version: "1.3.23"
+
+source:
+  fn: botocore-1.3.23.tar.gz
+  url: https://pypi.python.org/packages/source/b/botocore/botocore-1.3.23.tar.gz
+  md5: 464900da5330632950a6c5752c7fb8de
+
+requirements:
+  build:
+    - python
+    - jmespath >=0.7.1,<1.0.0
+    - python-dateutil >=2.1,<3.0.0
+    - docutils >=0.10
+
+  run:
+    - python
+    - jmespath >=0.7.1,<1.0.0
+    - python-dateutil >=2.1,<3.0.0
+    - docutils >=0.10
+
+test:
+  imports:
+    - botocore
+    - botocore.docs
+    - botocore.docs.bcdoc
+    - botocore.vendored
+    - botocore.vendored.requests
+    - botocore.vendored.requests.packages
+    - botocore.vendored.requests.packages.chardet
+    - botocore.vendored.requests.packages.urllib3
+    - botocore.vendored.requests.packages.urllib3.contrib
+    - botocore.vendored.requests.packages.urllib3.packages
+    - botocore.vendored.requests.packages.urllib3.packages.ssl_match_hostname
+    - botocore.vendored.requests.packages.urllib3.util
+
+about:
+  home: https://github.com/boto/botocore
+  license: Apache Software License
+  summary: 'Low-level, data-driven core of boto 3.'

--- a/conda-recipes/distributed/bld.bat
+++ b/conda-recipes/distributed/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipes/distributed/build.sh
+++ b/conda-recipes/distributed/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda-recipes/distributed/meta.yaml
+++ b/conda-recipes/distributed/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: distributed
+  version: "1.7.4"
+
+source:
+  path: ../..
+
+requirements:
+  build:
+    - python
+    - tornado
+    - toolz
+    - cloudpickle
+    - dask
+    - click
+    - boto3
+
+  run:
+    - python
+    - tornado
+    - toolz
+    - cloudpickle
+    - dask
+    - click
+    - boto3
+
+test:
+  imports:
+    - distributed
+    - distributed.diagnostics
+    - distributed.http
+
+about:
+  home: http://distributed.readthedocs.org/en/latest/
+  license: BSD
+  summary: 'Distributed computing'

--- a/conda-recipes/jmespath/bld.bat
+++ b/conda-recipes/jmespath/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/conda-recipes/jmespath/build.sh
+++ b/conda-recipes/jmespath/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/conda-recipes/jmespath/meta.yaml
+++ b/conda-recipes/jmespath/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: jmespath
+  version: "0.9.0"
+
+source:
+  fn: jmespath-0.9.0.tar.gz
+  url: https://pypi.python.org/packages/source/j/jmespath/jmespath-0.9.0.tar.gz
+  md5: 471b7d19bd153ac11a21d4fb7466800c
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - jmespath
+
+about:
+  home: https://github.com/jmespath/jmespath.py
+  license: MIT License
+  summary: 'JSON Matching Expressions'


### PR DESCRIPTION
Conda recipes for distributed and dependencies:

* distributed
* boto3
* botocore
* jmespath

Built for Python 2.7, 3.4, and 3.5 for linux-64, osx-64, and win-64.

I uploaded conda packages for the latest version of distributed (from master). The conda packages can be installed via:

```
conda install distributed -c blaze
```

Documentation to build packages is in `conda-recipes/README.md`.