### PR TITLE
add futures_to_dask_bag

### DIFF
--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -1,12 +1,14 @@
 """ This file is experimental and may disappear without warning """
 from __future__ import print_function, division, absolute_import
 
+from collections import Iterable
 from itertools import product
 from operator import getitem
 
 import dask
 from dask.context import _globals
 import dask.array as da
+import dask.bag as db
 import dask.dataframe as dd
 from dask.base import tokenize
 import numpy as np
@@ -160,6 +162,34 @@ def stack(futures, axis=0, executor=None):
 
 
 @gen.coroutine
+def _futures_to_dask_bag(futures, executor=None):
+    executor = default_executor(executor)
+
+    name = 'bag-from-futures-' + tokenize(*futures)
+    dsk = {(name, i): future for i, future in enumerate(futures)}
+
+    if _globals['get'] != executor.get:
+        print("Setting global dask scheduler to use distributed")
+        dask.set_options(get=executor.get)
+
+    raise gen.Return(db.Bag(dsk, name, len(futures)))
+
+
+def futures_to_dask_bag(futures, executor=None):
+    """ Convert a list of futures into a dask.bag
+
+    The futures should be point to Python iterables
+
+    Parameters
+    ----------
+    futures: iterable of Futures
+    executor: Executor (optional)
+    """
+    executor = default_executor(executor)
+    return sync(executor.loop, _futures_to_dask_bag, futures,
+                executor=executor)
+
+@gen.coroutine
 def _futures_to_collection(futures, executor=None, **kwargs):
     executor = default_executor(executor)
     element = futures
@@ -171,6 +201,8 @@ def _futures_to_collection(futures, executor=None, **kwargs):
         func = _futures_to_dask_dataframe
     elif 'numpy' in typ.__module__:
         func = _futures_to_dask_array
+    elif issubclass(typ, Iterable):
+        func = _futures_to_dask_bag
     else:
         raise NotImplementedError("First future of type %s.  Expected "
                 "numpy or pandas object" % typ.__name__)

--- a/distributed/collections.py
+++ b/distributed/collections.py
@@ -201,7 +201,7 @@ def _futures_to_collection(futures, executor=None, **kwargs):
         func = _futures_to_dask_dataframe
     elif 'numpy' in typ.__module__:
         func = _futures_to_dask_array
-    elif issubclass(typ, Iterable):
+    elif issubclass(typ, (tuple, list, set, frozenset)):
         func = _futures_to_dask_bag
     else:
         raise NotImplementedError("First future of type %s.  Expected "

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -266,7 +266,9 @@ class Scheduler(Server):
 
         for cor in self.coroutines:
             if cor.done():
-                raise cor.exception()
+                exc = cor.exception()
+                if exc:
+                    raise exc
 
         if self.status != 'running':
             self.listen(port)


### PR DESCRIPTION
cc @danielfrg @koverholt @quasiben @martindurant 

```python
In [1]: from distributed import Executor
e = 
In [2]: e = Executor('192.168.20.114:8786')

In [3]: lists = [['abc', 'def'], ['123', '456']]

In [4]: futures = e.scatter(lists)

In [5]: futures
Out[5]: 
[<Future: status: finished, key: ea74cd30-c933-11e5-8954-60672020cfac-0>,
 <Future: status: finished, key: ea74cd30-c933-11e5-8954-60672020cfac-1>]

In [6]: from distributed.collections import futures_to_collection

In [7]: b = futures_to_collection(futures)
Setting global dask scheduler to use distributed

In [8]: b
Out[8]: <dask.bag.core.Bag at 0x7f17eee5ecc0>

In [9]: b.map(str.upper).compute()
Out[9]: ['ABC', 'DEF', '123', '456']
```