### PR TITLE
Add CompatibleExecutor

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -5,7 +5,7 @@ from .client import scatter, gather, delete, clear, rpc
 from .diagnostics import progress
 from .utils import sync
 from .nanny import Nanny
-from .executor import Executor, wait, as_completed, default_executor
+from .executor import Executor, CompatibleExecutor, wait, as_completed, default_executor
 from .scheduler import Scheduler
 
 try:

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -805,6 +805,31 @@ class Executor(object):
             raise result
 
 
+class CompatibleExecutor(Executor):
+    """ A concurrent.futures-compatible Executor
+
+    A subclass of Executor that conforms to concurrent.futures API,
+    allowing swapping in for other Executors.
+    """
+
+    def map(self, func, *iterables, **kwargs):
+        """ Map a function on a sequence of arguments
+
+        Returns
+        -------
+        iter_results: iterable
+            Iterable yielding results of the map.
+
+        See Also
+        --------
+        Executor.map: for more info
+        """
+        list_of_futures = super(CompatibleExecutor, self).map(
+                                func, *iterables, **kwargs)
+        for f in list_of_futures:
+            yield f.result()
+
+
 @gen.coroutine
 def _wait(fs, timeout=None, return_when='ALL_COMPLETED'):
     if timeout is not None:

--- a/distributed/tests/test_executor.py
+++ b/distributed/tests/test_executor.py
@@ -18,8 +18,8 @@ from tornado import gen
 from distributed import Center, Worker, Nanny
 from distributed.core import rpc
 from distributed.client import WrappedKey
-from distributed.executor import (Executor, Future, _wait, wait, _as_completed,
-        as_completed, tokenize, _global_executor, default_executor)
+from distributed.executor import (Executor, Future, CompatibleExecutor, _wait, wait,
+        _as_completed, as_completed, tokenize, _global_executor, default_executor)
 from distributed.scheduler import Scheduler
 from distributed.sizeof import sizeof
 from distributed.utils import ignoring, sync, tmp_text
@@ -95,6 +95,18 @@ def test_map(s, a, b):
     L6 = e.map(f, range(5), y=y)
     results = yield e._gather(L6)
     assert results == list(range(20, 25))
+
+    yield e._shutdown()
+
+
+@gen_cluster()
+def test_aaa_compatible_map(s, a, b):
+    e = CompatibleExecutor((s.ip, s.port), start=False)
+    yield e._start()
+
+    results = e.map(inc, range(5))
+    assert not isinstance(results, list)
+    assert list(results) == list(map(inc, range(5)))
 
     yield e._shutdown()
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,6 +40,11 @@ Executor
 .. autoclass:: Executor
    :members:
 
+CompatibleExecutor
+------------------
+
+.. autoclass:: CompatibleExecutor
+    :members: map
 
 Future
 ------

--- a/docs/source/related-work.rst
+++ b/docs/source/related-work.rst
@@ -210,4 +210,8 @@ PEP-3184_.  It has a few notable differences:
    possible please raise an issue if this is of concrete importance to you.)
 *  Distributed generally does not support timeouts or callbacks
 
+``distributed.CompatibleExecutor`` is a subclass of ``distributed.Executor``
+that does conform to the ``concurrent.futures`` API,
+allowing it to be used as a drop-in replacement for other Executors using the common API.
+
 .. _PEP-3184: https://www.python.org/dev/peps/pep-3148/


### PR DESCRIPTION
a concurrent.futures-compatible Executor subclass. Only difference from Executor at this point: map yields results instead of returning list of Futures.

I'm not at all tied to the class name, but I couldn't think of a better one. Happy to change it if you have a better idea.

closes #91