### PR TITLE
Change entrypoints to use console_scripts instead of shebangs

### DIFF
--- a/distributed/cli/dcenter.py
+++ b/distributed/cli/dcenter.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 
 import click

--- a/distributed/cli/dcluster.py
+++ b/distributed/cli/dcluster.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from distributed.cluster import Cluster
 import click
 import os

--- a/distributed/cli/dscheduler.py
+++ b/distributed/cli/dscheduler.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 from sys import argv, exit
 import socket

--- a/distributed/cli/dworker.py
+++ b/distributed/cli/dworker.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 from sys import argv, exit
 import socket

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,14 @@ setup(name='distributed',
       maintainer_email='mrocklin@gmail.com',
       license='BSD',
       install_requires=requires,
-      packages=['distributed', 'distributed.diagnostics', 'distributed.http'],
+      packages=['distributed', 'distributed.cli', 'distributed.diagnostics', 'distributed.http'],
       long_description=(open('README.md').read() if os.path.exists('README.md')
                         else ''),
-      scripts=[os.path.join('bin', name)
-               for name in ['dcenter', 'dworker', 'dcluster', 'dscheduler']],
+      entry_points='''
+        [console_scripts]
+        dcenter=distributed.cli.dcenter:go
+        dscheduler=distributed.cli.dscheduler:go
+        dcluster=distributed.cli.dcluster:start
+        dworker=distributed.cli.dworker:go
+      ''',
       zip_safe=False)


### PR DESCRIPTION
Possible fix for https://github.com/blaze/distributed/issues/90

This fix is based on the click documentation: http://click.pocoo.org/5/setuptools

cc @izaid