### PR TITLE
Broadcast

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -169,7 +169,7 @@ def _scatter(center, data):
     center = coerce_to_rpc(center)
     ncores = yield center.ncores()
 
-    result, who_has, nbytes = yield scatter_to_workers(center, ncores, data)
+    result, who_has, nbytes = yield scatter_to_workers(ncores, data)
     raise Return(result)
 
 
@@ -180,7 +180,7 @@ _round_robin_counter = [0]
 
 
 @gen.coroutine
-def scatter_to_workers(center, ncores, data, report=True):
+def scatter_to_workers(ncores, data, report=True):
     """ Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers based on
@@ -189,15 +189,6 @@ def scatter_to_workers(center, ncores, data, report=True):
 
     See scatter for parameter docstring
     """
-    if isinstance(center, str):
-        ip, port = center.split(':')
-    elif isinstance(center, rpc):
-        ip, port = center.ip, center.port
-    elif isinstance(center, tuple):
-        ip, port = center
-    else:
-        raise TypeError("Bad type for center")
-
     if isinstance(ncores, Iterable) and not isinstance(ncores, dict):
         k = len(data) // len(ncores)
         ncores = {worker: k for worker in ncores}

--- a/distributed/executor.py
+++ b/distributed/executor.py
@@ -671,6 +671,9 @@ class Executor(object):
         workers: list of tuples (optional)
             Optionally constrain locations of data.
             Specify workers as hostname/port pairs, e.g. ``('127.0.0.1', 8787)``.
+        broadcast: bool (defaults to False)
+            Whether to send each data element to all workers.
+            By default we round-robin based on number of cores.
 
         Returns
         -------
@@ -696,6 +699,9 @@ class Executor(object):
         >>> seq = e.scatter(iter([1, 2, 3]))  # doctest: +SKIP
         >>> next(seq)  # doctest: +SKIP
         <Future: status: finished, key: c0a8a20f903a4915b94db8de3ea63195>,
+
+        Broadcast data to all workers
+        >>> [future] = e.scatter([element], broadcast=True)  # doctest: +SKIP
 
         See Also
         --------

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -21,7 +21,8 @@ from dask.order import order
 
 from .core import (rpc, coerce_to_rpc, connect, read, write, MAX_BUFFER_SIZE,
         Server, send_recv)
-from .client import unpack_remotedata, scatter_to_workers, gather_from_workers
+from .client import (unpack_remotedata, scatter_to_workers,
+        gather_from_workers, broadcast_to_workers)
 from .utils import (All, ignoring, clear_queue, _deps, get_ip,
         ignore_exceptions, ensure_ip, get_traceback, truncate_exception)
 
@@ -932,15 +933,23 @@ class Scheduler(Server):
                 self.in_play.remove(key)
 
     @gen.coroutine
-    def scatter(self, stream=None, data=None, workers=None, client=None):
+    def scatter(self, stream=None, data=None, workers=None, client=None,
+            broadcast=False):
         """ Send data out to workers """
         if not self.ncores:
             raise ValueError("No workers yet found.  "
                              "Try syncing with center.\n"
                              "  e.sync_center()")
-        ncores = workers if workers is not None else self.ncores
-        keys, who_has, nbytes = yield scatter_to_workers(ncores, data,
-                                            report=not not self.center)
+        if not broadcast:
+            ncores = workers if workers is not None else self.ncores
+            keys, who_has, nbytes = yield scatter_to_workers(ncores, data,
+                                                report=not not self.center)
+        else:
+            workers2 = workers if workers is not None else list(self.ncores)
+            keys, nbytes = yield broadcast_to_workers(workers2, data,
+                                                      report=False)
+            who_has = {k: set(workers2) for k in keys}
+
         self.update_data(who_has=who_has, nbytes=nbytes)
         self.client_wants_keys(keys=keys, client=client)
         raise gen.Return(keys)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -939,9 +939,7 @@ class Scheduler(Server):
                              "Try syncing with center.\n"
                              "  e.sync_center()")
         ncores = workers if workers is not None else self.ncores
-        keys, who_has, nbytes = yield scatter_to_workers(
-                                            self.center or self.address,
-                                            ncores, data,
+        keys, who_has, nbytes = yield scatter_to_workers(ncores, data,
                                             report=not not self.center)
         self.update_data(who_has=who_has, nbytes=nbytes)
         self.client_wants_keys(keys=keys, client=client)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -26,8 +26,7 @@ def test_scatter_delete(loop):
         assert set(c.who_has) == set(keys)
         assert all(len(v) == 1 for v in c.who_has.values())
 
-        keys2, who_has, nbytes = yield scatter_to_workers((c.ip, c.port),
-                                                          [a.address, b.address],
+        keys2, who_has, nbytes = yield scatter_to_workers([a.address, b.address],
                                                           [4, 5, 6])
 
         m = merge(a.data, b.data)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -10,9 +10,11 @@ from tornado.ioloop import IOLoop
 
 from distributed import Center, Worker
 from distributed.utils import ignoring
-from distributed.utils_test import cluster, loop, _test_cluster, cluster_center
+from distributed.utils_test import (cluster, loop, _test_cluster,
+        cluster_center, gen_cluster)
 from distributed.client import (_gather, _scatter, _delete, _clear,
-        scatter_to_workers, pack_data, gather, scatter, delete, clear)
+        scatter_to_workers, pack_data, gather, scatter, delete, clear,
+        broadcast_to_workers)
 
 
 def test_scatter_delete(loop):
@@ -137,3 +139,11 @@ def test_scatter_round_robins_between_calls(loop):
         assert b.data
 
     _test_cluster(f)
+
+
+@gen_cluster()
+def test_broadcast_to_workers(s, a, b):
+    keys, nbytes = yield broadcast_to_workers([a.address, b.address], [1, 2, 3])
+
+    assert len(keys) == 3
+    assert a.data == b.data == dict(zip(keys, [1, 2, 3]))


### PR DESCRIPTION
Add broadcast=True keyword argument to `Executor.scatter`

Currently it's not particularly efficient, but should be fine for small inputs.

```python
>>> a, b, c = e.scatter([1, 2, 3], broadcast=True)
```